### PR TITLE
Fix driver not support GL_EXT_gpu_shader4

### DIFF
--- a/src/main/resources/assets/canvas/shader/common_lib.glsl
+++ b/src/main/resources/assets/canvas/shader/common_lib.glsl
@@ -23,7 +23,7 @@ varying float v_diffuse;
 varying vec4 v_color_0;
 varying vec2 v_texcoord_0;
 varying vec4 v_light;
-flat varying vec2 v_flags;
+varying vec2 v_flags;
 
 #if LAYER_COUNT > 1
 varying vec4 v_color_1;


### PR DESCRIPTION
Not sure if this is the correct fix, but it solved mesa driver GL Error

```
[main/INFO]: OpenGL debug message, id=42, source=SHADER COMPILER, type=OTHER, severity=HIGH, message=0:2(12): warning: extension `GL_EXT_gpu_shader4' unsupported in vertex shader
[main/INFO]: OpenGL debug message, id=43, source=SHADER COMPILER, type=ERROR, severity=HIGH, message=0:26(1): error: syntax error, unexpected NEW_IDENTIFIER, expecting $end
[main/INFO]: OpenGL debug message, id=5, source=API, type=ERROR, severity=HIGH, message=GL_INVALID_OPERATION in glGetProgramInfoLog(program)
[main/ERROR]: misc.fail_create_shader
```