### PR TITLE
Fix shader InputStream not closing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	
 	modRuntime "grondag:fermion:${project.fermion_version}.+"
-    include "grondag:fermion:${project.fermion_version}.+""
+    include "grondag:fermion:${project.fermion_version}.+"
 	
     modImplementation ("grondag:fermion-varia:${project.fermion_varia_version}.+") {
         exclude group :"grondag"

--- a/src/main/java/grondag/canvas/material/AbstractGlShader.java
+++ b/src/main/java/grondag/canvas/material/AbstractGlShader.java
@@ -36,6 +36,7 @@ import grondag.canvas.varia.CanvasGlHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.language.I18n;
+import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 
@@ -253,13 +254,12 @@ abstract class AbstractGlShader {
     abstract String getSource();
 
     public static String getShaderSource(Identifier shaderSource) {
-        try {
-            ResourceManager rm = MinecraftClient.getInstance().getResourceManager();
-            InputStream in = rm.getResource(shaderSource).getInputStream();
-            if (in == null)
-                return "";
-            final Reader reader = new InputStreamReader(in);
-            return CharStreams.toString(reader);
+        ResourceManager resourceManager = MinecraftClient.getInstance().getResourceManager();
+
+        try(Resource resource = resourceManager.getResource(shaderSource)) {
+            try (Reader reader = new InputStreamReader(resource.getInputStream())) {
+                return CharStreams.toString(reader);
+            }
         } catch (IOException e) {
             return "";
         }


### PR DESCRIPTION
(Should) fix #40.

Got help in #mod-dev for this; a double `try with resources` setup was recommended. The first block retrieves the resource, which throws `IOException` if it doesn't exist. The second block no longer has a catch or null check, because (at least, from my understanding) a non-null resource will produce a non-null `InputStream`. Can add an extra null check if you want.

I wasn't sure what to do about versioning-- the latest repo version is 0.8, but the latest published version is 0.7.354. 