### PR TITLE
Fix 1.14 error logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@ modmenu_version=1.7.13+build.123
 
 clothconfig_version=1.1.2
 
-fermion_version=1.6
+fermion_version=1.3
 special_circumstances_version=1.3
-fermion_varia_version=1.6
+fermion_varia_version=1.3
 fermion_simulator_version=1.3
 canvas_version=0.7
 frex_version=1.0

--- a/src/main/java/grondag/canvas/material/AbstractGlShader.java
+++ b/src/main/java/grondag/canvas/material/AbstractGlShader.java
@@ -97,7 +97,7 @@ abstract class AbstractGlShader {
             if (GLX.glGetShaderi(glId, GLX.GL_COMPILE_STATUS) == GL11.GL_FALSE) {
                 isErrored = true;
                 error = CanvasGlHelper.getShaderInfoLog(glId);
-                if(error == null || error.isEmpty()) {
+                if(error.isEmpty()) {
                     error = "Unknown OpenGL Error.";
                 }
             }
@@ -115,7 +115,6 @@ abstract class AbstractGlShader {
             
             if(Configurator.conciseErrors) {
                 if(!isErrorNoticeComplete) {
-                    if(Configurator.conciseErrors)
                     CanvasMod.LOG.error(I18n.translate("error.canvas.fail_create_any_shader"));
                     isErrorNoticeComplete = true;
                 }

--- a/src/main/java/grondag/canvas/varia/CanvasGlHelper.java
+++ b/src/main/java/grondag/canvas/varia/CanvasGlHelper.java
@@ -136,7 +136,7 @@ public class CanvasGlHelper {
     }
 
     public static String getShaderInfoLog(int obj) {
-        return GLX.glGetProgramInfoLog(obj, GLX.glGetShaderi(obj, GL20.GL_INFO_LOG_LENGTH));
+        return GLX.glGetShaderInfoLog(obj, GLX.glGetShaderi(obj, GL20.GL_INFO_LOG_LENGTH));
     }
 
     public static boolean isVaoEnabled() {


### PR DESCRIPTION
Fixes #42 as we discussed in Discord.

A tad bit funny-- I spent some time working around the issue, and just as I was about to submit the PR, I noticed `CanvasGLHelper.getShaderInfoLog` wasn't used anymore. I went to delete it and noticed it was calling `glGetProgramInfoLog` rather than `glGetShaderInfoLog`.

That was the issue.

Also patched up 3 things:
  - Fermion 1.6 isn't in your repo for it; 1.3 is the latest
  - error from `CanvasGlHelper.getShaderInfoLog` won't be null; just need to check for empty
  - random small useless conditional, probably an accidental paste