### PR TITLE
Fixed pixel storage mode leak (#92)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ special_circumstances_version=1.7
 fermion_varia_version=2.3
 fermion_orientation_version=1.1
 frex_version=3.3
-jmx_version=1.13
+jmx_version=1.14
 
 jankson_version=3.0.1+j1.2.0
 clothconfig_version=4.7.0-unstable

--- a/src/main/java/grondag/canvas/apiimpl/mesh/MutableQuadViewImpl.java
+++ b/src/main/java/grondag/canvas/apiimpl/mesh/MutableQuadViewImpl.java
@@ -150,7 +150,6 @@ public abstract class MutableQuadViewImpl extends QuadViewImpl implements QuadEm
 	public final MutableQuadViewImpl fromVanilla(int[] quadData, int startIndex, boolean isItem) {
 		System.arraycopy(quadData, startIndex, data, baseIndex + HEADER_STRIDE, BASE_QUAD_STRIDE);
 		convertVanillaUvPrecision();
-		convertVanillaUvPrecision();
 		unmapSprite(0);
 		spriteMappedFlags = 0;
 

--- a/src/main/java/grondag/canvas/texture/SpriteInfoTexture.java
+++ b/src/main/java/grondag/canvas/texture/SpriteInfoTexture.java
@@ -17,6 +17,7 @@ package grondag.canvas.texture;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL21;
 
 import net.minecraft.client.MinecraftClient;
@@ -74,6 +75,10 @@ public class SpriteInfoTexture implements AutoCloseable {
 			GlStateManager.activeTexture(TextureData.SPRITE_INFO);
 			GlStateManager.bindTexture(glId);
 
+			GlStateManager.pixelStore(GL11.GL_UNPACK_ROW_LENGTH, 0);
+			GlStateManager.pixelStore(GL11.GL_UNPACK_SKIP_ROWS, 0);
+			GlStateManager.pixelStore(GL11.GL_UNPACK_SKIP_PIXELS, 0);
+			GlStateManager.pixelStore(GL11.GL_UNPACK_ALIGNMENT, 4);
 
 			image.upload();
 			image.close();


### PR DESCRIPTION
Fixed an issue where pixel storage modes would be leaked, meaning that the uploaded texture would be slightly offset. 

Specifically the `GL_UNPACK_SKIP_ROWS` mode caused the issue, however I've reset some of the other modes just to be sure. These leaked modes are from `NativeImage#uploadInternal`
Proof: 
![BfEyj0rsw9](https://user-images.githubusercontent.com/15876682/92158920-81139900-ee24-11ea-8323-22455b3c7425.gif)
