### PR TITLE
Pass camera and entity view vectors to shaders

### DIFF
--- a/src/main/java/grondag/canvas/varia/WorldDataManager.java
+++ b/src/main/java/grondag/canvas/varia/WorldDataManager.java
@@ -27,10 +27,11 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.Items;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 
 public class WorldDataManager {
-	public static final int LENGTH = 16;
+	public static final int LENGTH = 22;
 
 	private static final int WORLD_EFFECT_MODIFIER = 0;
 	private static final int RENDER_SECONDS = 1;
@@ -48,6 +49,8 @@ public class WorldDataManager {
 	private static final int HELD_LIGHT_BLUE = 13;
 	private static final int HELD_LIGHT_INTENSITY = 14;
 	private static final int RAIN_STRENGTH = 15;
+	private static final int CAMERA_VIEW = 16; // 3 elements wide
+	private static final int ENTITY_VIEW = 19; // 3 elements wide
 
 	// TODO: add player eye position (for 3rd-person views)
 	// TODO: add model origin to allow converting to world coordinates - or confirm view coordinates do that
@@ -167,11 +170,23 @@ public class WorldDataManager {
 				DATA[FOG_MODE] = 0.0f;
 			}
 		}
+
+		putViewVector(CAMERA_VIEW, camera.getYaw(), camera.getPitch());
+		putViewVector(ENTITY_VIEW, cameraEntity.yaw, cameraEntity.pitch);
 	}
 
 	public static void updateEmissiveColor(int color) {
 		DATA[EMISSIVE_COLOR_RED] = ((color >> 24) & 0xFF) / 255f;
 		DATA[EMISSIVE_COLOR_GREEN] = ((color >> 16) & 0xFF) / 255f;
 		DATA[EMISSIVE_COLOR_BLUE] = (color & 0xFF) / 255f;
+	}
+
+	private static void putViewVector(int index, float yaw, float pitch) {
+		float y = (float) Math.toRadians(yaw);
+		float p = (float) Math.toRadians(pitch);
+
+		DATA[index] = -MathHelper.sin(y) * MathHelper.cos(p);
+		DATA[index + 1] = -MathHelper.sin(p);
+		DATA[index + 2] = MathHelper.cos(y) * MathHelper.cos(p);
 	}
 }

--- a/src/main/resources/assets/canvas/shaders/internal/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/world.glsl
@@ -18,6 +18,8 @@
 #define _CV_HELD_LIGHT_BLUE 13
 #define _CV_HELD_LIGHT_INTENSITY 14
 #define _CV_RAIN_GRADIENT 15
+#define _CV_CAMERA_VIEW 16 // 3 elements wide
+#define _CV_ENTITY_VIEW 19 // 3 elements wide
 
 #define _CV_FLAG0_NIGHT_VISTION_ACTIVE  0
 #define _CV_FLAG0_HAS_SKYLIGHT            1
@@ -27,5 +29,5 @@
 #define _CV_FLAG0_IS_RAINING            5
 #define _CV_FLAG0_IS_THUNDERING        6
 
-uniform float[16] _cvu_world;
+uniform float[22] _cvu_world;
 uniform vec3 _cvu_modelOrigin;

--- a/src/main/resources/assets/canvas/shaders/wip/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/wip/world.glsl
@@ -18,6 +18,8 @@
 #define _CV_HELD_LIGHT_BLUE 13
 #define _CV_HELD_LIGHT_INTENSITY 14
 #define _CV_RAIN_GRADIENT 15
+#define _CV_CAMERA_VIEW 16 // 3 elements wide
+#define _CV_ENTITY_VIEW 19 // 3 elements wide
 
 #define _CV_FLAG0_NIGHT_VISTION_ACTIVE  0
 #define _CV_FLAG0_HAS_SKYLIGHT            1
@@ -27,7 +29,7 @@
 #define _CV_FLAG0_IS_RAINING            5
 #define _CV_FLAG0_IS_THUNDERING        6
 
-uniform float[16] _cvu_world;
+uniform float[22] _cvu_world;
 uniform vec3 _cvu_model_origin;
 
 // converts world space normals to model space of incoming vertex data

--- a/src/main/resources/assets/frex/shaders/api/camera.glsl
+++ b/src/main/resources/assets/frex/shaders/api/camera.glsl
@@ -1,0 +1,21 @@
+#include canvas:shaders/internal/world.glsl
+
+/******************************************************
+  frex:shaders/api/camera.glsl
+
+  Utilities for querying camera information
+******************************************************/
+
+/*
+ *  The view vector of the current camera, expressed in a normalised vector
+ */
+vec3 frx_cameraView() {
+	return vec3(_cvu_world[_CV_CAMERA_VIEW], _cvu_world[_CV_CAMERA_VIEW + 1], _cvu_world[_CV_CAMERA_VIEW + 2]);
+}
+
+/*
+ *  The view vector of the current entity focused by the camera, expressed in a normalised vector
+ */
+vec3 frx_entityView() {
+	return vec3(_cvu_world[_CV_ENTITY_VIEW], _cvu_world[_CV_ENTITY_VIEW + 1], _cvu_world[_CV_ENTITY_VIEW + 2]);
+}

--- a/src/main/resources/assets/frex/shaders/wip/api/camera.glsl
+++ b/src/main/resources/assets/frex/shaders/wip/api/camera.glsl
@@ -1,0 +1,21 @@
+#include canvas:shaders/internal/world.glsl
+
+/******************************************************
+  frex:shaders/api/camera.glsl
+
+  Utilities for querying camera information
+******************************************************/
+
+/*
+ *  The view vector of the current camera, expressed in a normalised vector
+ */
+vec3 frx_cameraView() {
+	return vec3(_cvu_world[_CV_CAMERA_VIEW], _cvu_world[_CV_CAMERA_VIEW + 1], _cvu_world[_CV_CAMERA_VIEW + 2]);
+}
+
+/*
+ *  The view vector of the current entity focused by the camera, expressed in a normalised vector
+ */
+vec3 frx_entityView() {
+	return vec3(_cvu_world[_CV_ENTITY_VIEW], _cvu_world[_CV_ENTITY_VIEW + 1], _cvu_world[_CV_ENTITY_VIEW + 2]);
+}


### PR DESCRIPTION
Does what the title says. Uses the `_cvu_world` uniform instead of its own.

Want to test it?
Go to `vanilla.frag` and include `frex:shaders/api/camera.glsl`
Replace line 72 with `vec4 raw = fragData.spriteColor * fragData.vertexColor * vec4(frx_cameraView(), 1) * vec4(frx_entityView(), 1);`
Go in game and test if the color changes when you look around, and check the camera view vector by pressing F5 to check if it also changes the color