### PR TITLE
Redstone ore - only emissive when lit state is true

### DIFF
--- a/src/main/resources/assets/minecraft/materialmaps/block/redstone_ore.json
+++ b/src/main/resources/assets/minecraft/materialmaps/block/redstone_ore.json
@@ -1,3 +1,8 @@
 {
-  "defaultMaterial": "canvas:redstone"
+  "defaultMaterial": "canvas:redstone",
+  "variants": {
+    "lit=false": {
+      "defaultMaterial": "fabric:standard"
+    }
+  }
 }


### PR DESCRIPTION
Mimics vanilla behavior.

![image](https://user-images.githubusercontent.com/8444172/99982666-704c4100-2ddd-11eb-99f6-d3cb6ed80f17.png)

Edit: to clarify, in vanilla the redstone ore is not emissive by default, but the entire block is emissive (including the stone part) when it has the block state `lit: true`. This is a sort of in-between of the current Canvas behavior and vanilla behavior.