### PR TITLE
Fix black dots when rendering enchantment glint on entities with material map

### DIFF
--- a/src/main/java/grondag/canvas/buffer/encoding/CanvasImmediate.java
+++ b/src/main/java/grondag/canvas/buffer/encoding/CanvasImmediate.java
@@ -52,7 +52,7 @@ public class CanvasImmediate extends Immediate implements FrexVertexConsumerProv
 		RenderMaterialImpl mat = ((MultiPhaseExt) renderLayer).canvas_materialState();
 		mat = contextState.mapMaterial(mat);
 
-		final VertexCollector result = collectors.get(mat);
+		final VertexCollector result = RenderLayerHelper.isExcluded(renderLayer) ? null : collectors.get(mat);
 
 		if (result == null) {
 			assert RenderLayerHelper.isExcluded(renderLayer) : "Unable to retrieve vertex collector for non-excluded render layer";


### PR DESCRIPTION
This appears to fix the issue but I didn't check for side effects.

To test:
1. Create any material map for `minecraft:player`. Try `"defaultMaterial": "canvas:emissive_transform"` since it's easy to observe.
2. Load command-enabled world. Give enchanted tool and armor to player. Equip tool and armor.
3. Observe player model in 3rd person view. Compare result to previous commit.