### PR TITLE
Fix crash with litematica

### DIFF
--- a/src/main/java/grondag/canvas/compat/Compat.java
+++ b/src/main/java/grondag/canvas/compat/Compat.java
@@ -81,6 +81,8 @@ public class Compat {
 			VoxelMapHolder.postRenderHandler.render(ctx.worldRenderer(), ctx.matrixStack(), ctx.tickDelta(), ctx.limitTime(), ctx.blockOutlines(), ctx.camera(), ctx.gameRenderer(), ctx.lightmapTextureManager(), ctx.projectionMatrix());
 		});
 
-		InvalidateRenderStateCallback.EVENT.register(LitematicaHolder.litematicaReload::run);
+		InvalidateRenderStateCallback.EVENT.register(() -> {
+			LitematicaHolder.litematicaReload.run();
+		});
 	}
 }


### PR DESCRIPTION
Prevents a crash caused by early initialization of LitematicaHolder without changing behavior. You can check it yourself, it's only two lines of code.

I also noticed that litematica rendering seems broken with fabulous graphics mode (not reproducible in vanilla), but that's probably unrelated to this PR.