### PR TITLE
Accept shadow sampler in process shader

### DIFF
--- a/src/main/java/grondag/canvas/shader/ProcessShader.java
+++ b/src/main/java/grondag/canvas/shader/ProcessShader.java
@@ -75,6 +75,8 @@ public class ProcessShader {
 				// PERF: should probably match on any sampler uniform type - names must be unique anyway
 				if (program.containsUniformSpec("sampler2DArray", samplerName)) {
 					program.uniformSampler("sampler2DArray", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
+				} else if (program.containsUniformSpec("sampler2DArrayShadow", samplerName)) {
+					program.uniformSampler("sampler2DArrayShadow", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
 				} else if (program.containsUniformSpec("sampler2D", samplerName)) {
 					program.uniformSampler("sampler2D", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
 				}


### PR DESCRIPTION
Allow process shader to define sampler uniform with type `sampler2DArrayShadow`.

Fixes `OpenGL debug message, id=1282, source=API, type=ERROR, severity=HIGH, message=GL_INVALID_OPERATION error generated. State(s) are invalid: program texture usage.` when attempting to do so.