### PR TITLE
Add render frame counter uniform

### DIFF
--- a/src/main/java/grondag/canvas/apiimpl/Canvas.java
+++ b/src/main/java/grondag/canvas/apiimpl/Canvas.java
@@ -18,6 +18,7 @@ package grondag.canvas.apiimpl;
 
 import java.util.function.BooleanSupplier;
 
+import grondag.canvas.varia.WorldDataManager;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import net.minecraft.client.MinecraftClient;
@@ -114,6 +115,7 @@ public class Canvas implements Renderer {
 		// LightmapHd.reload();
 		TerrainModelSpace.reload();
 		MaterialTextureState.reload();
+		WorldDataManager.reload();
 	}
 
 	@Override

--- a/src/main/java/grondag/canvas/varia/WorldDataManager.java
+++ b/src/main/java/grondag/canvas/varia/WorldDataManager.java
@@ -125,6 +125,9 @@ public class WorldDataManager {
 	// 15-18 reserved for cascades 0-3
 	static final int SHADOW_CENTER = 4 * 15;
 
+	private static final int VEC_RENDER_INFO = 4 * 19;
+	private static final int RENDER_FRAMES = VEC_RENDER_INFO;
+
 	private static final BitPacker32<Void> WORLD_FLAGS = new BitPacker32<>(null, null);
 	private static final BitPacker32<Void>.BooleanElement FLAG_HAS_SKYLIGHT = WORLD_FLAGS.createBooleanElement();
 	private static final BitPacker32<Void>.BooleanElement FLAG_IS_OVERWORLD = WORLD_FLAGS.createBooleanElement();
@@ -190,6 +193,7 @@ public class WorldDataManager {
 	private static final long baseRenderTime = System.currentTimeMillis();
 	private static int worldFlags;
 	private static int playerFlags;
+	static int renderFrames = 0;
 	static double smoothedEyeLightBlock = 0;
 	static double smoothedEyeLightSky = 0;
 	static double smoothedRainStrength = 0;
@@ -386,6 +390,13 @@ public class WorldDataManager {
 
 		DATA.put(SKYLIGHT_TRANSITION_FACTOR, factor);
 		return result;
+	}
+
+	/**
+	 * Called during render reload
+	 */
+	public static void reload() {
+		renderFrames = 0;
 	}
 
 	/**
@@ -591,6 +602,8 @@ public class WorldDataManager {
 
 		FlagData.DATA.put(FlagData.WORLD_DATA_INDEX, worldFlags);
 		FlagData.DATA.put(FlagData.PLAYER_DATA_INDEX, playerFlags);
+
+		DATA.put(RENDER_FRAMES, renderFrames++);
 	}
 
 	public static void updateEmissiveColor(int color) {

--- a/src/main/java/grondag/canvas/varia/WorldDataManager.java
+++ b/src/main/java/grondag/canvas/varia/WorldDataManager.java
@@ -190,9 +190,9 @@ public class WorldDataManager {
 	private static final BitPacker32<Void>.BooleanElement FLAG_HERO_OF_THE_VILLAGE = PLAYER_FLAGS.createBooleanElement();
 
 	public static final FloatBuffer DATA = BufferUtils.createFloatBuffer(LENGTH);
-	private static final long baseRenderTime = System.currentTimeMillis();
 	private static int worldFlags;
 	private static int playerFlags;
+	static long baseRenderTime = System.currentTimeMillis();
 	static int renderFrames = 0;
 	static double smoothedEyeLightBlock = 0;
 	static double smoothedEyeLightSky = 0;
@@ -396,6 +396,7 @@ public class WorldDataManager {
 	 * Called during render reload
 	 */
 	public static void reload() {
+		baseRenderTime = System.currentTimeMillis();
 		renderFrames = 0;
 	}
 

--- a/src/main/resources/assets/canvas/shaders/internal/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/world.glsl
@@ -60,6 +60,10 @@
 // 15 - 18 reserved for cascades 0-3
 #define _CV_SHADOW_CENTER 15
 
+// render frame count
+// unused x3
+#define _CV_RENDER_INFO 19
+
 #define _CV_FLAG_HAS_SKYLIGHT 0
 #define _CV_FLAG_IS_OVERWORLD 1
 #define _CV_FLAG_IS_NETHER 2

--- a/src/main/resources/assets/frex/shaders/api/world.glsl
+++ b/src/main/resources/assets/frex/shaders/api/world.glsl
@@ -23,6 +23,16 @@ float frx_renderSeconds() {
 }
 
 /*
+ * The number of frames this world has been rendering since the last render
+ * reload.
+ *
+ * Use this for effects that need a discrete increasing counter.
+ */
+int frx_renderFrames() {
+    return int(_cvu_world[_CV_RENDER_INFO].x);
+}
+
+/*
  * Day of the currently rendering world - integer portion only.
  * This is the apparent day, not the elapsed play time, which can
  * be different due to sleeping, /set time, etc.


### PR DESCRIPTION
Adds a frame counter uniform that resets on render reload.

Useful for temporal supersampling techniques that requires knowing precise frame count. Can also be used for operations that needs to run at frame 0.

Since I added a reload function for world data manager to reset the counter, I thought I made the render seconds api consistent with it docs while I'm at it. (The docs said "since the last render reload" but the actual implementation computes seconds since client init)

Lastly, this might not be the exact implementation that is in line with the rest of Canvas's design. The part where it converts float to int is especially sketchy. I don't mind if you close the PR and implement it yourself separately, I just think that Canvas will need this feature eventually.