### PR TITLE
Make renderFrames a uint uniform

### DIFF
--- a/src/main/java/grondag/canvas/shader/ShaderData.java
+++ b/src/main/java/grondag/canvas/shader/ShaderData.java
@@ -62,6 +62,8 @@ public class ShaderData {
 	public static final Consumer<GlProgram> COMMON_UNIFORM_SETUP = program -> {
 		program.uniformArray4f("_cvu_world", UniformRefreshFrequency.PER_FRAME, u -> u.setExternal(WorldDataManager.DATA), WorldDataManager.VECTOR_COUNT);
 
+		program.uniformArrayui("_cvu_world_uint", UniformRefreshFrequency.PER_FRAME, u -> u.setExternal(WorldDataManager.UINT_DATA), WorldDataManager.UINT_COUNT);
+
 		program.uniformArrayui("_cvu_flags", UniformRefreshFrequency.PER_FRAME, u -> u.setExternal(FlagData.DATA), FlagData.LENGTH);
 
 		program.uniformMatrix4fArray("_cvu_matrix", UniformRefreshFrequency.PER_FRAME, u -> u.set(MatrixState.DATA));

--- a/src/main/java/grondag/canvas/varia/WorldDataManager.java
+++ b/src/main/java/grondag/canvas/varia/WorldDataManager.java
@@ -17,6 +17,7 @@
 package grondag.canvas.varia;
 
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 
 import org.lwjgl.BufferUtils;
 
@@ -125,8 +126,9 @@ public class WorldDataManager {
 	// 15-18 reserved for cascades 0-3
 	static final int SHADOW_CENTER = 4 * 15;
 
-	private static final int VEC_RENDER_INFO = 4 * 19;
-	private static final int RENDER_FRAMES = VEC_RENDER_INFO;
+	public static final int UINT_COUNT = 1;
+	private static final int RENDER_FRAMES = 0;
+	public static final IntBuffer UINT_DATA = BufferUtils.createIntBuffer(UINT_COUNT);
 
 	private static final BitPacker32<Void> WORLD_FLAGS = new BitPacker32<>(null, null);
 	private static final BitPacker32<Void>.BooleanElement FLAG_HAS_SKYLIGHT = WORLD_FLAGS.createBooleanElement();
@@ -604,7 +606,7 @@ public class WorldDataManager {
 		FlagData.DATA.put(FlagData.WORLD_DATA_INDEX, worldFlags);
 		FlagData.DATA.put(FlagData.PLAYER_DATA_INDEX, playerFlags);
 
-		DATA.put(RENDER_FRAMES, renderFrames++);
+		UINT_DATA.put(RENDER_FRAMES, renderFrames++);
 	}
 
 	public static void updateEmissiveColor(int color) {

--- a/src/main/resources/assets/canvas/shaders/internal/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/world.glsl
@@ -60,9 +60,8 @@
 // 15 - 18 reserved for cascades 0-3
 #define _CV_SHADOW_CENTER 15
 
-// render frame count
-// unused x3
-#define _CV_RENDER_INFO 19
+// UINT ARRAY
+#define _CV_RENDER_FRAMES 0
 
 #define _CV_FLAG_HAS_SKYLIGHT 0
 #define _CV_FLAG_IS_OVERWORLD 1
@@ -78,6 +77,7 @@
 
 // update each frame
 uniform vec4[32] _cvu_world;
+uniform uint[1] _cvu_world_uint;
 uniform uint[4] _cvu_flags;
 
 #define _CV_MODEL_TO_WORLD 0

--- a/src/main/resources/assets/frex/shaders/api/world.glsl
+++ b/src/main/resources/assets/frex/shaders/api/world.glsl
@@ -28,8 +28,8 @@ float frx_renderSeconds() {
  *
  * Use this for effects that need a discrete increasing counter.
  */
-int frx_renderFrames() {
-    return int(_cvu_world[_CV_RENDER_INFO].x);
+uint frx_renderFrames() {
+    return _cvu_world_uint[_CV_RENDER_FRAMES];
 }
 
 /*


### PR DESCRIPTION
GPU logic messes with my mind and I didn't expect using integers to be such a big deal.

But anyway, renderFrames really was meant to be implemented as an integral value. Any float operation touching it makes it completely useless.