### PR TITLE
Alter "moved one block" frustum update requirement

### DIFF
--- a/src/main/java/grondag/canvas/render/TerrainFrustum.java
+++ b/src/main/java/grondag/canvas/render/TerrainFrustum.java
@@ -166,20 +166,20 @@ public class TerrainFrustum extends CanvasFrustum {
 		final double z = vec.z;
 
 		final long cameraBlockPos = camera.getBlockPos().asLong();
-		boolean movedOneBlock = false;
+		boolean cameraMoved = false;
 
 		if (cameraBlockPos != lastCameraBlockPos) {
 			lastCameraBlockPos = cameraBlockPos;
-			movedOneBlock = true;
+			cameraMoved = true;
 		} else {
-			// could move 1.0 or more diagonally within same block pos
+			// the assumption that occlusion data only needs updating if the camera moves 1 block doesn't hold up
 			final double dx = x - lastPositionX;
 			final double dy = y - lastPositionY;
 			final double dz = z - lastPositionZ;
-			movedOneBlock = dx * dx + dy * dy + dz * dz >= 1.0D;
+			cameraMoved = dx * dx + dy * dy + dz * dz >= 0.01D;
 		}
 
-		if (movedOneBlock) {
+		if (cameraMoved) {
 			++positionVersion;
 			lastPositionX = x;
 			lastPositionY = y;
@@ -201,7 +201,7 @@ public class TerrainFrustum extends CanvasFrustum {
 			modelMatrixUpdate = dPitch * dPitch + dYaw * dYaw >= paddingFov * paddingFov;
 		}
 
-		if (movedOneBlock || modelMatrixUpdate || !projectionMatrixExt.matches(occlusionProjMat)) {
+		if (cameraMoved || modelMatrixUpdate || !projectionMatrixExt.matches(occlusionProjMat)) {
 			++viewVersion;
 
 			lastViewX = x;


### PR DESCRIPTION
This makes the frustum updates the occluder (? I don't actually know how anything works) whenever the player moves instead of only if the player moves one block.

Video : https://user-images.githubusercontent.com/8444172/116459178-b24b4880-a88f-11eb-82c1-8181c46a9157.mp4

Note 1: it doesn't fix any culling bug (like the world disappearing when looking down) but it does make them less noticeable.
Note 2: this feels like a dirty fix, feel free to close this PR if you had something better in mind!
Note 3: I made this for the 1.16 branch because it's the one I use actively and no other reason. I can make future PRs targeted at the 1.17 branch if you prefer.