### PR TITLE
Material samplers + Texture loading

### DIFF
--- a/src/main/java/grondag/canvas/material/state/RenderState.java
+++ b/src/main/java/grondag/canvas/material/state/RenderState.java
@@ -177,6 +177,18 @@ public final class RenderState extends AbstractRenderState {
 			CanvasTextureState.activeTextureUnit(TextureData.MC_SPRITE_ATLAS);
 		}
 
+		if (Pipeline.config().materialProgram.samplerNames.length > 0) {
+			// Activate non-frex material program textures
+			for (int i = 0; i < Pipeline.config().materialProgram.samplerNames.length; i++) {
+				final int bindTarget = Pipeline.materialTextures().texTargets[i];
+				final int bind = Pipeline.materialTextures().texIds[i];
+				CanvasTextureState.activeTextureUnit(TextureData.PROGRAM_SAMPLERS + i);
+				CanvasTextureState.bindTexture(bindTarget, bind);
+				assert CanvasGlHelper.checkError();
+			}
+			CanvasTextureState.activeTextureUnit(TextureData.MC_SPRITE_ATLAS);
+		}
+
 		texture.enable(blur);
 		assert CanvasGlHelper.checkError();
 

--- a/src/main/java/grondag/canvas/pipeline/Pipeline.java
+++ b/src/main/java/grondag/canvas/pipeline/Pipeline.java
@@ -40,6 +40,7 @@ public class Pipeline {
 	private static boolean reload = true;
 	private static int lastWidth;
 	private static int lastHeight;
+	private static ProgramTextureData materialTextures;
 	static Pass[] onWorldRenderStart = { };
 	static Pass[] afterRenderHand = { };
 	static Pass[] fabulous = { };
@@ -101,6 +102,10 @@ public class Pipeline {
 
 	public static PipelineFramebuffer getFramebuffer(String name) {
 		return FRAMEBUFFERS.get(name);
+	}
+
+	public static ProgramTextureData materialTextures() {
+		return materialTextures;
 	}
 
 	static boolean needsReload() {
@@ -228,6 +233,8 @@ public class Pipeline {
 		} else {
 			defaultZenithAngle = 0f;
 		}
+
+		materialTextures = new ProgramTextureData(config.materialProgram.samplerImages);
 
 		isFabulous = config.fabulosity != null;
 

--- a/src/main/java/grondag/canvas/pipeline/ProgramTextureData.java
+++ b/src/main/java/grondag/canvas/pipeline/ProgramTextureData.java
@@ -1,0 +1,45 @@
+package grondag.canvas.pipeline;
+
+import grondag.canvas.pipeline.Image;
+import grondag.canvas.pipeline.Pipeline;
+import grondag.canvas.pipeline.config.ImageConfig;
+import grondag.canvas.pipeline.config.util.NamedDependency;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.AbstractTexture;
+import net.minecraft.util.Identifier;
+import org.lwjgl.opengl.GL46;
+
+public class ProgramTextureData {
+	final public int[] texIds;
+	final public int[] texTargets;
+
+	public ProgramTextureData(NamedDependency<ImageConfig>[] samplerImages) {
+		texIds = new int[samplerImages.length];
+		texTargets = new int[samplerImages.length];
+
+		for (int i = 0; i < samplerImages.length; ++i) {
+			final String imageName = samplerImages[i].name;
+
+			int imageBind = 0;
+			int bindTarget = GL46.GL_TEXTURE_2D;
+
+			if (imageName.contains(":")) {
+				final AbstractTexture tex = MinecraftClient.getInstance().getTextureManager().getTexture(new Identifier(imageName));
+
+				if (tex != null) {
+					imageBind = tex.getGlId();
+				}
+			} else {
+				final Image img = Pipeline.getImage(imageName);
+
+				if (img != null) {
+					imageBind = img.glId();
+					bindTarget = img.config.target;
+				}
+			}
+
+			texIds[i] = imageBind;
+			texTargets[i] = bindTarget;
+		}
+	}
+}

--- a/src/main/java/grondag/canvas/pipeline/pass/ProgramPass.java
+++ b/src/main/java/grondag/canvas/pipeline/pass/ProgramPass.java
@@ -18,15 +18,10 @@ package grondag.canvas.pipeline.pass;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import grondag.canvas.pipeline.ProgramTextureData;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL21;
-import org.lwjgl.opengl.GL46;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.texture.AbstractTexture;
-import net.minecraft.util.Identifier;
-
-import grondag.canvas.pipeline.Image;
 import grondag.canvas.pipeline.Pipeline;
 import grondag.canvas.pipeline.PipelineManager;
 import grondag.canvas.pipeline.config.PassConfig;
@@ -34,8 +29,7 @@ import grondag.canvas.render.CanvasTextureState;
 import grondag.canvas.shader.ProcessShader;
 
 class ProgramPass extends Pass {
-	final int[] binds;
-	final int[] bindTargets;
+	final ProgramTextureData textures;
 
 	ProcessShader shader;
 
@@ -43,34 +37,7 @@ class ProgramPass extends Pass {
 		super(config);
 
 		shader = Pipeline.getShader(config.program.name);
-
-		binds = new int[config.samplerImages.length];
-		bindTargets = new int[config.samplerImages.length];
-
-		for (int i = 0; i < config.samplerImages.length; ++i) {
-			final String imageName = config.samplerImages[i].name;
-
-			int imageBind = 0;
-			int bindTarget = GL46.GL_TEXTURE_2D;
-
-			if (imageName.contains(":")) {
-				final AbstractTexture tex = MinecraftClient.getInstance().getTextureManager().getTexture(new Identifier(imageName));
-
-				if (tex != null) {
-					imageBind = tex.getGlId();
-				}
-			} else {
-				final Image img = Pipeline.getImage(imageName);
-
-				if (img != null) {
-					imageBind = img.glId();
-					bindTarget = img.config.target;
-				}
-			}
-
-			binds[i] = imageBind;
-			bindTargets[i] = bindTarget;
-		}
+		textures = new ProgramTextureData(config.samplerImages);
 	}
 
 	@Override
@@ -91,11 +58,11 @@ class ProgramPass extends Pass {
 		PipelineManager.setProjection(width, height);
 		RenderSystem.viewport(0, 0, width, height);
 
-		final int slimit = binds.length;
+		final int slimit = textures.texIds.length;
 
 		for (int i = 0; i < slimit; ++i) {
 			CanvasTextureState.activeTextureUnit(GL21.GL_TEXTURE0 + i);
-			CanvasTextureState.bindTexture(bindTargets[i], binds[i]);
+			CanvasTextureState.bindTexture(textures.texTargets[i], textures.texIds[i]);
 		}
 
 		shader.activate().lod(config.lod).size(width, height);

--- a/src/main/java/grondag/canvas/shader/ProcessShader.java
+++ b/src/main/java/grondag/canvas/shader/ProcessShader.java
@@ -71,15 +71,8 @@ public class ProcessShader {
 
 			for (final String samplerName : samplers) {
 				final int n = tex++;
-
-				// PERF: should probably match on any sampler uniform type - names must be unique anyway
-				if (program.containsUniformSpec("sampler2DArray", samplerName)) {
-					program.uniformSampler("sampler2DArray", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
-				} else if (program.containsUniformSpec("sampler2DArrayShadow", samplerName)) {
-					program.uniformSampler("sampler2DArrayShadow", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
-				} else if (program.containsUniformSpec("sampler2D", samplerName)) {
-					program.uniformSampler("sampler2D", samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
-				}
+				final String samplerType = SamplerTypeHelper.getSamplerType(program, samplerName);
+				program.uniformSampler(samplerType, samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(n));
 			}
 
 			program.load();

--- a/src/main/java/grondag/canvas/shader/SamplerTypeHelper.java
+++ b/src/main/java/grondag/canvas/shader/SamplerTypeHelper.java
@@ -1,0 +1,66 @@
+package grondag.canvas.shader;
+
+import grondag.canvas.shader.GlProgram;
+import grondag.frex.api.material.UniformRefreshFrequency;
+
+public class SamplerTypeHelper {
+	public static final String[] samplerTypes = new String[]{
+		// float samplers
+		"sampler1D",
+		"sampler2D",
+		"sampler3D",
+		"samplerCube",
+		"sampler2DRect",
+		"sampler1DArray",
+		"sampler2DArray",
+		"samplerCubeArray",
+		"samplerBuffer",
+		"sampler2DMS",
+		"sampler2DMSArray",
+
+		// integer samplers
+		"isampler1D",
+		"isampler2D",
+		"isampler3D",
+		"isamplerCube",
+		"isampler2DRect",
+		"isampler1DArray",
+		"isampler2DArray",
+		"isamplerCubeArray",
+		"isamplerBuffer",
+		"isampler2DMS",
+		"isampler2DMSArray",
+
+		// unsigned integer samplers
+		"usampler1D",
+		"usampler2D",
+		"usampler3D",
+		"usamplerCube",
+		"usampler2DRect",
+		"usampler1DArray",
+		"usampler2DArray",
+		"usamplerCubeArray",
+		"usamplerBuffer",
+		"usampler2DMS",
+		"usampler2DMSArray",
+
+		// shadow samplers
+		"sampler1DShadow",
+		"sampler2DShadow",
+		"samplerCubeShadow",
+		"sampler2DRectShadow",
+		"sampler1DArrayShadow",
+		"sampler2DArrayShadow",
+		"samplerCubeArrayShadow",
+	};
+
+	public static String getSamplerType(GlProgram program, String samplerName) {
+		for (String type:samplerTypes) {
+			if (program.containsUniformSpec(type, samplerName)) {
+				return type;
+			}
+		}
+
+		return "sampler2D";
+	}
+}

--- a/src/main/java/grondag/canvas/shader/ShaderData.java
+++ b/src/main/java/grondag/canvas/shader/ShaderData.java
@@ -18,6 +18,7 @@ package grondag.canvas.shader;
 
 import java.util.function.Consumer;
 
+import grondag.canvas.pipeline.Pipeline;
 import org.lwjgl.opengl.GL21;
 
 import net.minecraft.util.Identifier;
@@ -57,6 +58,13 @@ public class ShaderData {
 		program.uniformSampler("sampler2D", "_cvu_spriteInfo", UniformRefreshFrequency.ON_LOAD, u -> u.set(TextureData.SPRITE_INFO - GL21.GL_TEXTURE0));
 
 		program.uniformSampler("sampler2D", "_cvu_materialInfo", UniformRefreshFrequency.ON_LOAD, u -> u.set(TextureData.MATERIAL_INFO - GL21.GL_TEXTURE0));
+
+		for (int i = 0; i < Pipeline.config().materialProgram.samplerNames.length; i++) {
+			final int texId = i;
+			final String samplerName = Pipeline.config().materialProgram.samplerNames[i];
+			final String samplerType = SamplerTypeHelper.getSamplerType(program, samplerName);
+			program.uniformSampler(samplerType, samplerName, UniformRefreshFrequency.ON_LOAD, u -> u.set(TextureData.PROGRAM_SAMPLERS - GL21.GL_TEXTURE0 + texId));
+		}
 	};
 
 	public static final Consumer<GlProgram> COMMON_UNIFORM_SETUP = program -> {

--- a/src/main/java/grondag/canvas/texture/TextureData.java
+++ b/src/main/java/grondag/canvas/texture/TextureData.java
@@ -32,4 +32,5 @@ public class TextureData {
 	// want these outside of the range managed by Mojang's damn GlStateManager
 	public static final int SHADOWMAP = GL21.GL_TEXTURE12;
 	public static final int SHADOWMAP_TEXTURE = GL21.GL_TEXTURE13;
+	public static final int PROGRAM_SAMPLERS = GL21.GL_TEXTURE14;
 }


### PR DESCRIPTION
This PR combines #243 with a more robust implementation of #242.

Here is a briefing on what those PRs do in case you forgot/haven't seen them:

- #242 : attempts to register arbitrary `namespaced:location` textures if not registered already.
- #243 : implements the currently unimplemented `samplers` and `samplerImages` on `materialProgram` definition. also adds a `SamplerTypeHelper` to allow binding uniforms of any sampler types (instead of just 2d, 2d array, and 2d shadow array).

This PR is more robust than #242 because it uses `TextureManager.registerTexture(Identifier)` directly instead of trying to handle `IOException` manually. As a result, instead of `null`, missing textures will return a `MissingSprite` texture which is helpful for pipeline developers (better than rendering nothing!)

Additionally, here are some notes on texture loading:

- `TextureManasger` is a resource reload listeners. It will remove any `MissingSprite` textures on resource reload, may prevent memory leak.
- `ResourceTexture.load()` also loads any texture metadata (mcmeta) alongside the texture. In this way textures can be defined in the "minecraft way".

Some images:

- Loading the enchantment glint in forward (gui) and deferred (world) rendering in Lumi Lights

![image](https://user-images.githubusercontent.com/8444172/116773075-60681580-aa7d-11eb-9e03-fab9f19f2cfc.png)

- `MissingSprite` sun and enchant glint

![image](https://user-images.githubusercontent.com/8444172/116773092-8beb0000-aa7d-11eb-9e42-17af26849bb3.png)

Github stuff:
Closes #242 
Closes #243 