### PR TITLE
Add a state flag for rendering hand, limit updating of modelOriginType

### DIFF
--- a/src/main/java/grondag/canvas/material/state/RenderState.java
+++ b/src/main/java/grondag/canvas/material/state/RenderState.java
@@ -136,8 +136,7 @@ public final class RenderState extends AbstractRenderState {
 		LIGHTMAP_STATE.setEnabled(true);
 		LINE_STATE.setEnabled(lines);
 
-		depthShader.updateCommonUniforms();
-		depthShader.setContextInfo(texture.atlasInfo(), target.index);
+		depthShader.updateContextInfo(texture.atlasInfo(), target.index);
 		depthShader.setModelOrigin(x, y, z);
 		depthShader.setCascade(cascade);
 
@@ -199,8 +198,7 @@ public final class RenderState extends AbstractRenderState {
 		LIGHTMAP_STATE.setEnabled(true);
 		LINE_STATE.setEnabled(lines);
 
-		shader.updateCommonUniforms();
-		shader.setContextInfo(texture.atlasInfo(), target.index);
+		shader.updateContextInfo(texture.atlasInfo(), target.index);
 		shader.setModelOrigin(x, y, z);
 	}
 

--- a/src/main/java/grondag/canvas/material/state/RenderState.java
+++ b/src/main/java/grondag/canvas/material/state/RenderState.java
@@ -136,7 +136,7 @@ public final class RenderState extends AbstractRenderState {
 		LIGHTMAP_STATE.setEnabled(true);
 		LINE_STATE.setEnabled(lines);
 
-		depthShader.activate(this);
+		depthShader.updateCommonUniforms();
 		depthShader.setContextInfo(texture.atlasInfo(), target.index);
 		depthShader.setModelOrigin(x, y, z);
 		depthShader.setCascade(cascade);
@@ -199,7 +199,7 @@ public final class RenderState extends AbstractRenderState {
 		LIGHTMAP_STATE.setEnabled(true);
 		LINE_STATE.setEnabled(lines);
 
-		shader.activate(this);
+		shader.updateCommonUniforms();
 		shader.setContextInfo(texture.atlasInfo(), target.index);
 		shader.setModelOrigin(x, y, z);
 	}

--- a/src/main/java/grondag/canvas/mixin/MixinGameRenderer.java
+++ b/src/main/java/grondag/canvas/mixin/MixinGameRenderer.java
@@ -34,6 +34,7 @@ import grondag.canvas.perf.Timekeeper;
 import grondag.canvas.pipeline.BufferDebug;
 import grondag.canvas.pipeline.PipelineManager;
 import grondag.canvas.render.CanvasWorldRenderer;
+import grondag.canvas.shader.data.ScreenRenderState;
 
 @Mixin(GameRenderer.class)
 public abstract class MixinGameRenderer implements GameRendererExt {
@@ -48,6 +49,7 @@ public abstract class MixinGameRenderer implements GameRendererExt {
 
 	@Inject(method = "renderHand", require = 1, at = @At("RETURN"))
 	private void afterRenderHand(CallbackInfo ci) {
+		ScreenRenderState.setRenderingHand(false);
 		PipelineManager.afterRenderHand();
 
 		if (Configurator.enableBufferDebug) {

--- a/src/main/java/grondag/canvas/render/CanvasWorldRenderer.java
+++ b/src/main/java/grondag/canvas/render/CanvasWorldRenderer.java
@@ -94,6 +94,7 @@ import grondag.canvas.shader.GlProgram;
 import grondag.canvas.shader.GlProgramManager;
 import grondag.canvas.shader.data.MatrixData;
 import grondag.canvas.shader.data.MatrixState;
+import grondag.canvas.shader.data.ScreenRenderState;
 import grondag.canvas.shader.data.ShaderDataManager;
 import grondag.canvas.terrain.occlusion.PotentiallyVisibleRegionSorter;
 import grondag.canvas.terrain.occlusion.TerrainIterator;
@@ -844,6 +845,7 @@ public class CanvasWorldRenderer extends WorldRenderer {
 
 		RenderSystem.applyModelViewMatrix();
 		MatrixState.set(MatrixState.SCREEN);
+		ScreenRenderState.setRenderingHand(true);
 	}
 
 	@Override

--- a/src/main/java/grondag/canvas/shader/GlMaterialProgram.java
+++ b/src/main/java/grondag/canvas/shader/GlMaterialProgram.java
@@ -47,8 +47,8 @@ public class GlMaterialProgram extends GlProgram {
 	private final ObjectArrayList<UniformSamplerImpl> configuredSamplers;
 
 	private static final FloatBuffer MODEL_ORIGIN = BufferUtils.createFloatBuffer(8);
-	private static final BitPacker32<Void> MISC_FLAGS = new BitPacker32<>(null, null);
-	private static final BitPacker32<Void>.BooleanElement FLAG_MISC_HAND = MISC_FLAGS.createBooleanElement();
+	private static final BitPacker32<Void> CONTEXT_FLAGS = new BitPacker32<>(null, null);
+	private static final BitPacker32<Void>.BooleanElement CONTEXT_FLAG_HAND = CONTEXT_FLAGS.createBooleanElement();
 
 	GlMaterialProgram(Shader vertexShader, Shader fragmentShader, CanvasVertexFormat format, ProgramType programType) {
 		super(vertexShader, fragmentShader, format, programType);
@@ -157,7 +157,7 @@ public class GlMaterialProgram extends GlProgram {
 		}
 
 		contextInfoData[_CV_MATERIAL_TARGET] = targetIndex;
-		contextInfoData[_CV_CONTEXT_FLAGS] = FLAG_MISC_HAND.setValue(ScreenRenderState.renderingHand(), contextInfoData[_CV_CONTEXT_FLAGS]);
+		contextInfoData[_CV_CONTEXT_FLAGS] = CONTEXT_FLAG_HAND.setValue(ScreenRenderState.renderingHand(), contextInfoData[_CV_CONTEXT_FLAGS]);
 
 		contextInfo.set(contextInfoData);
 		contextInfo.upload();

--- a/src/main/java/grondag/canvas/shader/data/ScreenRenderState.java
+++ b/src/main/java/grondag/canvas/shader/data/ScreenRenderState.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2019, 2020 grondag
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package grondag.canvas.shader.data;
+
+/**
+ * Describes general rendering state that encompasses hand and GUI rendering.
+ */
+public class ScreenRenderState {
+	private static boolean renderingHand = false;
+	private static boolean stateChanged = true;
+
+	public static void clearStateChange() {
+		stateChanged = false;
+	}
+
+	public static void setRenderingHand(boolean isRenderingHand) {
+		renderingHand = isRenderingHand;
+		setStateChanged();
+	}
+
+	public static boolean renderingHand() {
+		return renderingHand;
+	}
+
+	public static boolean stateChanged() {
+		return stateChanged;
+	}
+
+	private static void setStateChanged() {
+		stateChanged = true;
+	}
+}

--- a/src/main/resources/assets/canvas/shaders/internal/program.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/program.glsl
@@ -10,8 +10,11 @@
 #define _CV_ATLAS_WIDTH 0
 #define _CV_ATLAS_HEIGHT 1
 #define _CV_TARGET_INDEX 2
+#define _CV_CONTEXT_FLAGS 3
 
-uniform int[3] _cvu_context;
+#define _CV_CONTEXT_FLAG_HAND 0
+
+uniform int[4] _cvu_context;
 
 #define _CV_MAX_SHADER_COUNT 0
 
@@ -40,7 +43,7 @@ bool _cv_programDiscard() {
 
 #ifdef VERTEX_SHADER
 void _cv_setupProgram() {
-	if (_cvu_context[_CV_ATLAS_WIDTH] == 0.0) {
+	if (_cvu_context[_CV_ATLAS_WIDTH] == 0) {
 		_cvu_program = texelFetch(_cvu_materialInfo, in_material);
 		_cvu_program.w = _cv_testCondition(_cvu_program.w) ? 1 : 0;
 		_cvv_spriteBounds = vec4(0.0, 0.0, 1.0, 1.0);

--- a/src/main/resources/assets/canvas/shaders/internal/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/world.glsl
@@ -95,10 +95,6 @@ uniform int _cvu_model_origin_type;
 uniform mat3 _cvu_normal_model_matrix;
 uniform vec2 _cvu_fog_info;
 
-#define _CV_MISC_HAND 0
-
-uniform uint _cvu_misc_flags;
-
 #define _CV_MAT_VIEW 0
 #define _CV_MAT_VIEW_INVERSE 1
 #define _CV_MAT_VIEW_LAST 2

--- a/src/main/resources/assets/canvas/shaders/internal/world.glsl
+++ b/src/main/resources/assets/canvas/shaders/internal/world.glsl
@@ -95,6 +95,10 @@ uniform int _cvu_model_origin_type;
 uniform mat3 _cvu_normal_model_matrix;
 uniform vec2 _cvu_fog_info;
 
+#define _CV_MISC_HAND 0
+
+uniform uint _cvu_misc_flags;
+
 #define _CV_MAT_VIEW 0
 #define _CV_MAT_VIEW_INVERSE 1
 #define _CV_MAT_VIEW_LAST 2

--- a/src/main/resources/assets/canvas/shaders/pipeline/dev.frag
+++ b/src/main/resources/assets/canvas/shaders/pipeline/dev.frag
@@ -126,7 +126,7 @@ const vec4[] cascadeColors = vec4[4](
 void frx_writePipelineFragment(in frx_FragmentData fragData) {
 	vec4 a = fragData.spriteColor * fragData.vertexColor;
 
-	if (frx_isGui()) {
+	if (frx_isGui() && !frx_isHand()) {
 		if (fragData.diffuse) {
 			float df = p_diffuseGui(frx_normal);
 			df = df + (1.0 - df) * fragData.emissivity;

--- a/src/main/resources/assets/canvas/shaders/pipeline/standard.frag
+++ b/src/main/resources/assets/canvas/shaders/pipeline/standard.frag
@@ -109,7 +109,7 @@ frx_FragmentData frx_createPipelineFragment() {
 void frx_writePipelineFragment(in frx_FragmentData fragData) {
 	vec4 a = fragData.spriteColor * fragData.vertexColor;
 
-	if (frx_isGui()) {
+	if (frx_isGui() && !frx_isHand()) {
 		if (fragData.diffuse) {
 			float df = p_diffuseGui(frx_normal);
 			df = df + (1.0 - df) * fragData.emissivity;

--- a/src/main/resources/assets/frex/shaders/api/view.glsl
+++ b/src/main/resources/assets/frex/shaders/api/view.glsl
@@ -144,6 +144,13 @@ int frx_modelOriginType() {
 }
 
 /*
+ * True when rendering hand.
+ */
+bool frx_isHand() {
+    return frx_bitValue(_cvu_misc_flags, _CV_MISC_HAND) == 1;
+}
+
+/*
  * True when rendering to GUI.
  */
 bool frx_isGui() {

--- a/src/main/resources/assets/frex/shaders/api/view.glsl
+++ b/src/main/resources/assets/frex/shaders/api/view.glsl
@@ -147,7 +147,7 @@ int frx_modelOriginType() {
  * True when rendering hand.
  */
 bool frx_isHand() {
-    return frx_bitValue(_cvu_misc_flags, _CV_MISC_HAND) == 1;
+    return frx_bitValue(uint(_cvu_context[_CV_CONTEXT_FLAGS]), _CV_CONTEXT_FLAG_HAND) == 1;
 }
 
 /*


### PR DESCRIPTION
- new `frx_isHand()` api in `view.glsl`
- hand render is described in a most creatively named "misc flag"
- hand render flag is uploaded only when necessary
- important: `frx_isGui()` definition is unchanged as it would invalidate/require renaming of frx_guiViewProjectionMatrix() (so technically hand is still part of gui. pipeline/material authors need to exclude it explicitly). if necessary, this can be changed, but the PR title and scope will need to be changed as well.
- bonus: model origin type is uploaded only when matrix state was changed