### PR TITLE
Invalidate atlas index providers on resource reload. Fixes #235

### DIFF
--- a/src/main/java/grondag/canvas/CanvasMod.java
+++ b/src/main/java/grondag/canvas/CanvasMod.java
@@ -40,6 +40,7 @@ import grondag.canvas.config.ConfigManager;
 import grondag.canvas.config.Configurator;
 import grondag.canvas.mixinterface.RenderLayerExt;
 import grondag.canvas.pipeline.config.PipelineLoader;
+import grondag.canvas.texture.ResourceCache;
 import grondag.frex.api.RendererFeature;
 import grondag.frex.api.fluid.FluidQuadSupplier;
 
@@ -93,5 +94,6 @@ public class CanvasMod implements ClientModInitializer {
 		});
 
 		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(PipelineLoader.INSTANCE);
+		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(ResourceCache.cacheReloader);
 	}
 }

--- a/src/main/java/grondag/canvas/CanvasMod.java
+++ b/src/main/java/grondag/canvas/CanvasMod.java
@@ -40,7 +40,7 @@ import grondag.canvas.config.ConfigManager;
 import grondag.canvas.config.Configurator;
 import grondag.canvas.mixinterface.RenderLayerExt;
 import grondag.canvas.pipeline.config.PipelineLoader;
-import grondag.canvas.texture.ResourceCache;
+import grondag.canvas.texture.ResourceCacheManager;
 import grondag.frex.api.RendererFeature;
 import grondag.frex.api.fluid.FluidQuadSupplier;
 
@@ -94,6 +94,6 @@ public class CanvasMod implements ClientModInitializer {
 		});
 
 		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(PipelineLoader.INSTANCE);
-		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(ResourceCache.cacheReloader);
+		ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(ResourceCacheManager.cacheReloader);
 	}
 }

--- a/src/main/java/grondag/canvas/material/state/RenderMaterialImpl.java
+++ b/src/main/java/grondag/canvas/material/state/RenderMaterialImpl.java
@@ -28,6 +28,7 @@ import grondag.canvas.CanvasMod;
 import grondag.canvas.config.Configurator;
 import grondag.canvas.shader.MaterialShaderId;
 import grondag.canvas.texture.MaterialIndexer;
+import grondag.canvas.texture.ResourceCache;
 import grondag.frex.api.material.RenderMaterial;
 
 public final class RenderMaterialImpl extends AbstractRenderState implements RenderMaterial {
@@ -36,7 +37,7 @@ public final class RenderMaterialImpl extends AbstractRenderState implements Ren
 	public final int collectorIndex;
 	public final RenderState renderState;
 	public final int shaderFlags;
-	private MaterialIndexer dongle;
+	private ResourceCache<MaterialIndexer> dongle;
 
 	/** Vanilla render layer name if we derived from a vanilla render layer. */
 	public final String renderLayerName;
@@ -73,6 +74,12 @@ public final class RenderMaterialImpl extends AbstractRenderState implements Ren
 
 	public static RenderMaterialImpl fromIndex(int index) {
 		return VALUES[index];
+	}
+
+	public static void resourceReload() {
+		for (RenderMaterialImpl e:MAP.values()) {
+			e.dongle = null;
+		}
 	}
 
 	@Override
@@ -121,14 +128,11 @@ public final class RenderMaterialImpl extends AbstractRenderState implements Ren
 	}
 
 	public MaterialIndexer dongle() {
-		MaterialIndexer result = dongle;
-
-		if (result == null) {
-			result = texture.materialIndexProvider().getIndexer(this);
-			dongle = result;
+		if (dongle == null) {
+			dongle = new ResourceCache<>(() -> texture.materialIndexProvider().getIndexer(this));
 		}
 
-		return result;
+		return dongle.getOrLoad();
 	}
 
 	@Override

--- a/src/main/java/grondag/canvas/texture/MaterialIndexProvider.java
+++ b/src/main/java/grondag/canvas/texture/MaterialIndexProvider.java
@@ -111,10 +111,14 @@ public abstract class MaterialIndexProvider {
 		}
 	}
 
-	private static final Object2ObjectOpenHashMap<Identifier, ResourceCache<AtlasIndexProvider>> ATLAS_PROVIDERS = new Object2ObjectOpenHashMap<>(64, Hash.VERY_FAST_LOAD_FACTOR);
+	private static final Object2ObjectOpenHashMap<Identifier, AtlasIndexProvider> ATLAS_PROVIDERS = new Object2ObjectOpenHashMap<>(64, Hash.VERY_FAST_LOAD_FACTOR);
 
 	public static final synchronized MaterialIndexProvider getOrCreateForAtlas(Identifier id) {
-		return ATLAS_PROVIDERS.getOrDefault(id, new ResourceCache<>(() -> new AtlasIndexProvider(id))).getOrLoad();
+		return ATLAS_PROVIDERS.computeIfAbsent(id, AtlasIndexProvider::new);
+	}
+
+	public static void reload() {
+		ATLAS_PROVIDERS.clear();
 	}
 
 	public static final MaterialIndexProvider GENERIC = new SimpleIndexProvider();

--- a/src/main/java/grondag/canvas/texture/MaterialIndexProvider.java
+++ b/src/main/java/grondag/canvas/texture/MaterialIndexProvider.java
@@ -111,10 +111,10 @@ public abstract class MaterialIndexProvider {
 		}
 	}
 
-	private static final Object2ObjectOpenHashMap<Identifier, AtlasIndexProvider> ATLAS_PROVIDERS = new Object2ObjectOpenHashMap<>(64, Hash.VERY_FAST_LOAD_FACTOR);
+	private static final Object2ObjectOpenHashMap<Identifier, ResourceCache<AtlasIndexProvider>> ATLAS_PROVIDERS = new Object2ObjectOpenHashMap<>(64, Hash.VERY_FAST_LOAD_FACTOR);
 
 	public static final synchronized MaterialIndexProvider getOrCreateForAtlas(Identifier id) {
-		return ATLAS_PROVIDERS.computeIfAbsent(id, AtlasIndexProvider::new);
+		return ATLAS_PROVIDERS.getOrDefault(id, new ResourceCache<>(() -> new AtlasIndexProvider(id))).getOrLoad();
 	}
 
 	public static final MaterialIndexProvider GENERIC = new SimpleIndexProvider();

--- a/src/main/java/grondag/canvas/texture/ResourceCache.java
+++ b/src/main/java/grondag/canvas/texture/ResourceCache.java
@@ -1,0 +1,47 @@
+package grondag.canvas.texture;
+
+import java.util.function.Supplier;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+
+public final class ResourceCache<T> {
+	public static final ObjectArrayList<ResourceCache> CACHED = new ObjectArrayList<>(64);
+	public static final SimpleSynchronousResourceReloadListener cacheReloader = new SimpleSynchronousResourceReloadListener() {
+		private final Identifier ID = new Identifier("canvas:resource_cache_reloader");
+
+		@Override
+		public Identifier getFabricId() {
+			return ID;
+		}
+
+		@Override
+		public void reload(ResourceManager resourceManager) {
+			CACHED.forEach(ResourceCache::invalidate);
+		}
+	};
+
+	public ResourceCache(Supplier<T> loader) {
+		CACHED.add(this);
+		this.loader = loader;
+	}
+
+	private final Supplier<T> loader;
+	private T value;
+
+	private void invalidate() {
+		value = null;
+	}
+
+	public T getOrLoad() {
+		if (value == null) {
+			value = loader.get();
+		}
+
+		return value;
+	}
+}

--- a/src/main/java/grondag/canvas/texture/ResourceCache.java
+++ b/src/main/java/grondag/canvas/texture/ResourceCache.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019, 2020 grondag
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
 package grondag.canvas.texture;
 
 import java.util.function.Supplier;

--- a/src/main/java/grondag/canvas/texture/ResourceCache.java
+++ b/src/main/java/grondag/canvas/texture/ResourceCache.java
@@ -2,38 +2,16 @@ package grondag.canvas.texture;
 
 import java.util.function.Supplier;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
-
-import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
-
 public final class ResourceCache<T> {
-	public static final ObjectArrayList<ResourceCache> CACHED = new ObjectArrayList<>(64);
-	public static final SimpleSynchronousResourceReloadListener cacheReloader = new SimpleSynchronousResourceReloadListener() {
-		private final Identifier ID = new Identifier("canvas:resource_cache_reloader");
-
-		@Override
-		public Identifier getFabricId() {
-			return ID;
-		}
-
-		@Override
-		public void reload(ResourceManager resourceManager) {
-			CACHED.forEach(ResourceCache::invalidate);
-		}
-	};
-
 	public ResourceCache(Supplier<T> loader) {
-		CACHED.add(this);
+		ResourceCacheManager.CACHED.add(this);
 		this.loader = loader;
 	}
 
 	private final Supplier<T> loader;
 	private T value;
 
-	private void invalidate() {
+	public void invalidate() {
 		value = null;
 	}
 

--- a/src/main/java/grondag/canvas/texture/ResourceCacheManager.java
+++ b/src/main/java/grondag/canvas/texture/ResourceCacheManager.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019, 2020 grondag
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
 package grondag.canvas.texture;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;

--- a/src/main/java/grondag/canvas/texture/ResourceCacheManager.java
+++ b/src/main/java/grondag/canvas/texture/ResourceCacheManager.java
@@ -1,0 +1,26 @@
+package grondag.canvas.texture;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+
+public class ResourceCacheManager {
+	public static final ObjectArrayList<ResourceCache> CACHED = new ObjectArrayList<>(64);
+	public static final SimpleSynchronousResourceReloadListener cacheReloader = new SimpleSynchronousResourceReloadListener() {
+		private final Identifier ID = new Identifier("canvas:resource_cache_reloader");
+
+		@Override
+		public Identifier getFabricId() {
+			return ID;
+		}
+
+		@Override
+		public void reload(ResourceManager resourceManager) {
+			MaterialIndexProvider.reload();
+			CACHED.forEach(ResourceCache::invalidate);
+		}
+	};
+}


### PR DESCRIPTION
Fixes #235 by adding a new class `ResourceCache` which manages objects that should be invalidated upon resource reload.

The following objects are converted into `ResourceCache`:
- `RenderMaterialImpl.dongle`
- ~~`MaterialIndexProvider.ATLAS_PROVIDERS` elements~~

`MaterialIndexProvider.ATLAS_PROVIDERS` is cleared on resource reload.