### PR TITLE
Added support debug object labels

### DIFF
--- a/src/main/java/grondag/canvas/pipeline/Image.java
+++ b/src/main/java/grondag/canvas/pipeline/Image.java
@@ -20,9 +20,11 @@ import java.nio.ByteBuffer;
 
 import com.mojang.blaze3d.platform.TextureUtil;
 
+import grondag.canvas.CanvasMod;
 import grondag.canvas.pipeline.config.ImageConfig;
 import grondag.canvas.render.CanvasTextureState;
 import grondag.canvas.varia.GFX;
+import org.lwjgl.opengl.GL11;
 
 public class Image {
 	public final ImageConfig config;
@@ -46,6 +48,7 @@ public class Image {
 			glId = TextureUtil.generateTextureId();
 
 			CanvasTextureState.bindTexture(config.target, glId);
+			GFX.objectLabel(GL11.GL_TEXTURE, glId, "IMG_" + config.name); // Yes, it needs to be GL_TEXTURE and not GL_TEXTURE_2D or the one its binding to
 
 			final int[] params = config.texParamPairs;
 			final int limit = params.length;

--- a/src/main/java/grondag/canvas/pipeline/Image.java
+++ b/src/main/java/grondag/canvas/pipeline/Image.java
@@ -48,7 +48,7 @@ public class Image {
 			glId = TextureUtil.generateTextureId();
 
 			CanvasTextureState.bindTexture(config.target, glId);
-			GFX.objectLabel(GL11.GL_TEXTURE, glId, "IMG_" + config.name); // Yes, it needs to be GL_TEXTURE and not GL_TEXTURE_2D or the one its binding to
+			GFX.objectLabel(GL11.GL_TEXTURE, glId, "IMG " + config.name); // Yes, it needs to be GL_TEXTURE and not GL_TEXTURE_2D or the one its binding to
 
 			final int[] params = config.texParamPairs;
 			final int limit = params.length;

--- a/src/main/java/grondag/canvas/pipeline/Pipeline.java
+++ b/src/main/java/grondag/canvas/pipeline/Pipeline.java
@@ -195,7 +195,7 @@ public class Pipeline {
 				continue;
 			}
 
-			SHADERS.put(program.name, new ProcessShader(program.vertexSource, program.fragmentSource, program.samplerNames));
+			SHADERS.put(program.name, new ProcessShader(program.name, program.vertexSource, program.fragmentSource, program.samplerNames));
 		}
 
 		for (final FramebufferConfig buffer : config.framebuffers) {

--- a/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
@@ -76,6 +76,7 @@ public class PipelineFramebuffer {
 		fboGlId = GFX.genFramebuffer();
 
 		GFX.bindFramebuffer(GFX.GL_FRAMEBUFFER, fboGlId);
+		GFX.objectLabel(GFX.GL_FRAMEBUFFER, fboGlId, "FBO_" + config.name);
 
 		if (config.colorAttachments.length == 0) {
 			GFX.glDrawBuffer(GFX.GL_NONE);

--- a/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
@@ -76,7 +76,7 @@ public class PipelineFramebuffer {
 		fboGlId = GFX.genFramebuffer();
 
 		GFX.bindFramebuffer(GFX.GL_FRAMEBUFFER, fboGlId);
-		GFX.objectLabel(GFX.GL_FRAMEBUFFER, fboGlId, "FBO_" + config.name);
+		GFX.objectLabel(GFX.GL_FRAMEBUFFER, fboGlId, "FBO " + config.name);
 
 		if (config.colorAttachments.length == 0) {
 			GFX.glDrawBuffer(GFX.GL_NONE);

--- a/src/main/java/grondag/canvas/pipeline/PipelineManager.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineManager.java
@@ -219,9 +219,9 @@ public class PipelineManager {
 
 		mc.options.graphicsMode = Pipeline.isFabulous() ? GraphicsMode.FABULOUS : GraphicsMode.FANCY;
 
-		debugShader = new ProcessShader(new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/copy_lod.frag"), "_cvu_input");
-		debugDepthShader = new ProcessShader(new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/visualize_depth.frag"), "_cvu_input");
-		debugDepthArrayShader = new ProcessShader(new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/visualize_depth_array.frag"), "_cvu_input");
+		debugShader = new ProcessShader("debug", new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/copy_lod.frag"), "_cvu_input");
+		debugDepthShader = new ProcessShader("debug_depth", new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/visualize_depth.frag"), "_cvu_input");
+		debugDepthArrayShader = new ProcessShader("debug_depth_array", new Identifier("canvas:shaders/pipeline/post/simple_full_frame.vert"), new Identifier("canvas:shaders/pipeline/post/visualize_depth_array.frag"), "_cvu_input");
 		Pipeline.defaultFbo.bind();
 		CanvasTextureState.bindTexture(0);
 

--- a/src/main/java/grondag/canvas/shader/GlMaterialProgram.java
+++ b/src/main/java/grondag/canvas/shader/GlMaterialProgram.java
@@ -51,7 +51,7 @@ public class GlMaterialProgram extends GlProgram {
 	private static final BitPacker32<Void>.BooleanElement CONTEXT_FLAG_HAND = CONTEXT_FLAGS.createBooleanElement();
 
 	GlMaterialProgram(Shader vertexShader, Shader fragmentShader, CanvasVertexFormat format, ProgramType programType) {
-		super(vertexShader, fragmentShader, format, programType);
+		super(programType.isTerrain ? "material_terrain" : "material", vertexShader, fragmentShader, format, programType);
 		modelOrigin = (UniformArray4fImpl) uniformArray4f("_cvu_model_origin", UniformRefreshFrequency.ON_LOAD, u -> u.setExternal(null), 2);
 		contextInfo = (UniformArrayiImpl) uniformArrayi("_cvu_context", UniformRefreshFrequency.ON_LOAD, u -> { }, 4);
 		modelOriginType = (Uniform1iImpl) uniform1i("_cvu_model_origin_type", UniformRefreshFrequency.ON_LOAD, u -> u.set(MatrixState.get().ordinal()));

--- a/src/main/java/grondag/canvas/shader/GlProgram.java
+++ b/src/main/java/grondag/canvas/shader/GlProgram.java
@@ -176,7 +176,7 @@ public class GlProgram {
 			activateInner();
 
 			// Label needs to be set after binding the program
-			if (created) GFX.objectLabel(GFX.GL_PROGRAM, programId(), "PRO_" + name);
+			if (created) GFX.objectLabel(GFX.GL_PROGRAM, programId(), "PRO " + name);
 		}
 	}
 

--- a/src/main/java/grondag/canvas/shader/GlProgram.java
+++ b/src/main/java/grondag/canvas/shader/GlProgram.java
@@ -16,19 +16,6 @@
 
 package grondag.canvas.shader;
 
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.util.function.Consumer;
-
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.jetbrains.annotations.Nullable;
-import org.lwjgl.BufferUtils;
-import org.lwjgl.system.MemoryUtil;
-
-import net.minecraft.client.resource.language.I18n;
-import net.minecraft.util.math.Matrix3f;
-import net.minecraft.util.math.Matrix4f;
-
 import grondag.canvas.CanvasMod;
 import grondag.canvas.buffer.format.CanvasVertexFormat;
 import grondag.canvas.config.Configurator;
@@ -37,24 +24,19 @@ import grondag.canvas.mixinterface.Matrix4fExt;
 import grondag.canvas.shader.data.ShaderUniforms;
 import grondag.canvas.varia.GFX;
 import grondag.frex.api.material.Uniform;
-import grondag.frex.api.material.Uniform.Uniform1f;
-import grondag.frex.api.material.Uniform.Uniform1i;
-import grondag.frex.api.material.Uniform.Uniform1ui;
-import grondag.frex.api.material.Uniform.Uniform2f;
-import grondag.frex.api.material.Uniform.Uniform2i;
-import grondag.frex.api.material.Uniform.Uniform2ui;
-import grondag.frex.api.material.Uniform.Uniform3f;
-import grondag.frex.api.material.Uniform.Uniform3i;
-import grondag.frex.api.material.Uniform.Uniform3ui;
-import grondag.frex.api.material.Uniform.Uniform4f;
-import grondag.frex.api.material.Uniform.Uniform4i;
-import grondag.frex.api.material.Uniform.Uniform4ui;
-import grondag.frex.api.material.Uniform.UniformArray4f;
-import grondag.frex.api.material.Uniform.UniformArrayf;
-import grondag.frex.api.material.Uniform.UniformArrayi;
-import grondag.frex.api.material.Uniform.UniformArrayui;
-import grondag.frex.api.material.Uniform.UniformMatrix3f;
+import grondag.frex.api.material.Uniform.*;
 import grondag.frex.api.material.UniformRefreshFrequency;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.util.math.Matrix3f;
+import net.minecraft.util.math.Matrix4f;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.util.function.Consumer;
 
 public class GlProgram {
 	static {
@@ -64,6 +46,7 @@ public class GlProgram {
 	}
 
 	private static GlProgram activeProgram;
+	private final String name;
 	private final Shader vertexShader;
 	private final Shader fragmentShader;
 	public final CanvasVertexFormat vertexFormat;
@@ -78,7 +61,8 @@ public class GlProgram {
 	private boolean isErrored = false;
 	private boolean needsLoad = true;
 
-	GlProgram(Shader vertexShader, Shader fragmentShader, CanvasVertexFormat format, ProgramType programType) {
+	GlProgram(String name, Shader vertexShader, Shader fragmentShader, CanvasVertexFormat format, ProgramType programType) {
+		this.name = name;
 		this.vertexShader = vertexShader;
 		this.fragmentShader = fragmentShader;
 		this.programType = programType;
@@ -176,6 +160,8 @@ public class GlProgram {
 	}
 
 	public final void activate() {
+		boolean created = needsLoad;
+
 		if (needsLoad) {
 			load();
 			needsLoad = false;
@@ -188,6 +174,9 @@ public class GlProgram {
 		if (activeProgram != this) {
 			activeProgram = this;
 			activateInner();
+
+			// Label needs to be set after binding the program
+			if (created) GFX.objectLabel(GFX.GL_PROGRAM, programId(), "PRO_" + name);
 		}
 	}
 

--- a/src/main/java/grondag/canvas/shader/GlShader.java
+++ b/src/main/java/grondag/canvas/shader/GlShader.java
@@ -192,11 +192,14 @@ public class GlShader implements Shader {
 				String extension = name.substring(dotI + 1);
 				name = name.substring(0, dotI);
 
-				if (extension.equals("vert")) name = "VERT_" + name;
-				else if (extension.equals("frag")) name = "FRAG_" + name;
+				if (extension.equals("vert")) name = "SHA_VERT " + name;
+				else if (extension.equals("frag")) name = "SHA_FRAG " + name;
+				else name = "SHA " + name;
+			} else {
+				name = "SHA " + name;
 			}
 
-			GFX.objectLabel(GFX.GL_SHADER, glId, "SHA_" + name);
+			GFX.objectLabel(GFX.GL_SHADER, glId, name);
 		}
 	}
 

--- a/src/main/java/grondag/canvas/shader/GlShader.java
+++ b/src/main/java/grondag/canvas/shader/GlShader.java
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.io.CharStreams;
+import grondag.canvas.varia.CanvasGlHelper;
 import org.anarres.cpp.DefaultPreprocessorListener;
 import org.anarres.cpp.Preprocessor;
 import org.anarres.cpp.StringLexerSource;
@@ -179,6 +180,23 @@ public class GlShader implements Shader {
 			outputDebugSource(source, error);
 		} else if (Configurator.shaderDebug) {
 			outputDebugSource(source, null);
+		}
+
+		// Explicitly checking CanvasGlHelper.supportsKhrDebug() to not generate the name if KHR_debug is not supported
+		if (!isErrored && CanvasGlHelper.supportsKhrDebug()) {
+			int slashI = shaderSourceId.getPath().lastIndexOf('/');
+			String name = slashI != -1 ? shaderSourceId.getPath().substring(slashI + 1) : shaderSourceId.getPath();
+
+			int dotI = name.lastIndexOf('.');
+			if (dotI != -1) {
+				String extension = name.substring(dotI + 1);
+				name = name.substring(0, dotI);
+
+				if (extension.equals("vert")) name = "VERT_" + name;
+				else if (extension.equals("frag")) name = "FRAG_" + name;
+			}
+
+			GFX.objectLabel(GFX.GL_SHADER, glId, "SHA_" + name);
 		}
 	}
 

--- a/src/main/java/grondag/canvas/shader/ProcessShader.java
+++ b/src/main/java/grondag/canvas/shader/ProcessShader.java
@@ -16,16 +16,16 @@
 
 package grondag.canvas.shader;
 
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.Matrix4f;
-
 import grondag.canvas.buffer.format.CanvasVertexFormats;
 import grondag.canvas.shader.GlProgram.Uniform1iImpl;
 import grondag.canvas.shader.GlProgram.Uniform2iImpl;
 import grondag.canvas.shader.GlProgram.UniformMatrix4fImpl;
 import grondag.frex.api.material.UniformRefreshFrequency;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Matrix4f;
 
 public class ProcessShader {
+	private final String name;
 	private final Identifier fragmentId;
 	private final Identifier vertexId;
 	private final String[] samplers;
@@ -35,7 +35,8 @@ public class ProcessShader {
 	private Uniform1iImpl layer;
 	private UniformMatrix4fImpl projMatrix;
 
-	public ProcessShader(Identifier vertexId, Identifier fragmentId, String... samplers) {
+	public ProcessShader(String name, Identifier vertexId, Identifier fragmentId, String... samplers) {
+		this.name = name;
 		this.fragmentId = fragmentId;
 		this.vertexId = vertexId;
 		this.samplers = samplers;
@@ -65,7 +66,7 @@ public class ProcessShader {
 		if (program == null) {
 			final Shader vs = GlShaderManager.INSTANCE.getOrCreateVertexShader(vertexId, ProgramType.PROCESS);
 			final Shader fs = GlShaderManager.INSTANCE.getOrCreateFragmentShader(fragmentId, ProgramType.PROCESS);
-			program = new GlProgram(vs, fs, CanvasVertexFormats.PROCESS_VERTEX_UV, ProgramType.PROCESS);
+			program = new GlProgram(name, vs, fs, CanvasVertexFormats.PROCESS_VERTEX_UV, ProgramType.PROCESS);
 			size = (Uniform2iImpl) program.uniform2i("frxu_size", UniformRefreshFrequency.ON_LOAD, u -> u.set(1, 1));
 			lod = (Uniform1iImpl) program.uniform1i("frxu_lod", UniformRefreshFrequency.ON_LOAD, u -> u.set(0));
 			layer = (Uniform1iImpl) program.uniform1i("frxu_layer", UniformRefreshFrequency.ON_LOAD, u -> u.set(0));

--- a/src/main/java/grondag/canvas/varia/CanvasGlHelper.java
+++ b/src/main/java/grondag/canvas/varia/CanvasGlHelper.java
@@ -17,22 +17,25 @@
 package grondag.canvas.varia;
 
 import com.mojang.blaze3d.platform.GLX;
+import grondag.canvas.CanvasMod;
+import grondag.canvas.config.Configurator;
+import net.minecraft.client.MinecraftClient;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GLCapabilities;
 
-import net.minecraft.client.MinecraftClient;
-
-import grondag.canvas.CanvasMod;
-import grondag.canvas.config.Configurator;
-
 public class CanvasGlHelper {
 	private static boolean supportsPersistentMapped = false;
+	private static boolean supportsKhrDebug = false;
 
 	private static String maxGlVersion = "3.2";
 
 	public static boolean supportsPersistentMapped() {
 		return supportsPersistentMapped;
+	}
+
+	public static boolean supportsKhrDebug() {
+		return supportsKhrDebug;
 	}
 
 	public static String maxGlVersion() {
@@ -46,6 +49,7 @@ public class CanvasGlHelper {
 
 		final GLCapabilities caps = GL.getCapabilities();
 		supportsPersistentMapped = caps.glBufferStorage != 0;
+		supportsKhrDebug = caps.GL_KHR_debug;
 		maxGlVersion = maxGlVersion(caps);
 
 		if (Configurator.logMachineInfo) {
@@ -64,6 +68,7 @@ public class CanvasGlHelper {
 		log.info(String.format(" OpenGL (Reported): %s", GLX.getOpenGLVersionString()));
 		log.info(String.format(" OpenGL (Available): %s", maxGlVersion));
 		log.info(String.format(" glBufferStorage: %s", caps.glBufferStorage == 0 ? "N" : "Y"));
+		log.info(String.format(" KHR_debug: %s", supportsKhrDebug() ? "Y" : "N"));
 		log.info(" (This message can be disabled by configuring logMachineInfo = false.)");
 		log.info("========================================================================");
 	}

--- a/src/main/java/grondag/canvas/varia/GFX.java
+++ b/src/main/java/grondag/canvas/varia/GFX.java
@@ -153,6 +153,13 @@ public class GFX extends GL46C {
 		assert logError(String.format("glEnable(%s)", GlSymbolLookup.reverseLookup(target)));
 	}
 
+	public static void objectLabel(int target, int id, CharSequence label) {
+		if (CanvasGlHelper.supportsKhrDebug()) {
+			glObjectLabel(target, id, label);
+			assert logError("objectLabel");
+		}
+	}
+
 	public static void bindBuffer(int target, int buffer) {
 		glBindBuffer(target, buffer);
 		assert logError(String.format("glBindBuffer(%s, %d)", GlSymbolLookup.reverseLookup(target), buffer));


### PR DESCRIPTION
Support for KHR_debug is checked using `GLCapabilities.GL_KHR_debug` field.
I have added prefixes for the names to better distinguish between objects with the same name, here is a list of them:

- `FBO_` - framebuffer
- `PRO_` - shader program
- `IMG_` - image / texture
- `SHA_VERT_` - vertex shader
- `SHA_FRAG_` - fragment shader
- `SHA_` - unknown shader type

Shader type is determined by the file extension.
Here is a screenshot of RenderDoc using Canvas Standard:
![image](https://user-images.githubusercontent.com/25082624/133439576-14e3efb9-a6e6-4007-9adb-67e80d116a3c.png)

I have tested this on all 3 built in pipelines and with Lumi Lights.