### PR TITLE
Added object labels to resource textures

### DIFF
--- a/src/main/java/grondag/canvas/mixin/MixinResourceTexture.java
+++ b/src/main/java/grondag/canvas/mixin/MixinResourceTexture.java
@@ -1,0 +1,26 @@
+package grondag.canvas.mixin;
+
+import grondag.canvas.varia.GFX;
+import net.minecraft.client.texture.AbstractTexture;
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.ResourceTexture;
+import net.minecraft.util.Identifier;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ResourceTexture.class)
+public abstract class MixinResourceTexture extends AbstractTexture {
+	@Shadow
+	@Final
+	protected Identifier location;
+
+	@Inject(method = "upload", at = @At("TAIL"))
+	private void onUpload(NativeImage nativeImage, boolean bl, boolean bl2, CallbackInfo ci) {
+		GFX.objectLabel(GL11.GL_TEXTURE, getGlId(), "IMG " + location.toString());
+	}
+}

--- a/src/main/resources/mixins.canvas.client.json
+++ b/src/main/resources/mixins.canvas.client.json
@@ -53,7 +53,8 @@
 	"MixinVideoOptionsScreen",
 	"MixinWindow",
 	"MixinWorldChunk",
-	"MixinWorldRenderer"
+	"MixinWorldRenderer",
+	"MixinResourceTexture"
   ],
   "injectors": {
 	"defaultRequire": 1


### PR DESCRIPTION
My first intention was just to provide object labels for custom texture sampler images but there is no way to differentiate between them and normal resource textures (well there would be, but that requires binding the texture after loaded its from the config). So I came to the conclusion there is no harm if every resource texture has one :D