### PR TITLE
Add 1.17 Emmissives to canvas_default

### DIFF
--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/lights/item/light.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/lights/item/light.json
@@ -1,0 +1,8 @@
+{
+  "intensity": 0.93,
+  "red": 1.0,
+  "green": 1.0,
+  "blue": 0.8,
+  "worksInFluid": false
+}
+

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/amethyst_cluster.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/amethyst_cluster.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/candle.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/candle.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+	"lit=true": {
+	  "defaultMaterial": "canvas:luminance_glow"
+	}
+  }
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/cave_vines.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/cave_vines.json
@@ -1,0 +1,8 @@
+{
+  "defaultMaterial": "fabric:standard",
+  "variants": {
+	"berries=true": {
+	  "defaultMaterial": "canvas:warm_glow"
+	}
+  }
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/cave_vines_plant.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/cave_vines_plant.json
@@ -1,0 +1,8 @@
+{
+  "defaultMaterial": "fabric:standard",
+  "variants": {
+	"berries=true": {
+	  "defaultMaterial": "canvas:warm_glow"
+	}
+  }
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/glow_lichen.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/glow_lichen.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/large_amethyst_bud.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/large_amethyst_bud.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/medium_amethyst_bud.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/medium_amethyst_bud.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/sculk_sensor.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/sculk_sensor.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/small_amethyst_bud.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/small_amethyst_bud.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/spore_blossom.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/block/spore_blossom.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:redstone"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/entity/glow_item_frame.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/entity/glow_item_frame.json
@@ -1,0 +1,3 @@
+{
+ 	"defaultMaterial": "canvas:warm_glow_transform"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/entity/glow_squid.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/entity/glow_squid.json
@@ -1,0 +1,3 @@
+{
+	"defaultMaterial": "frex:emissive_transform"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/amethyst_shard.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/amethyst_shard.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/glow_berries.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/glow_berries.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/glow_ink_sac.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/glow_ink_sac.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/light.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/item/light.json
@@ -1,0 +1,3 @@
+{
+  "defaultMaterial": "canvas:luminance_glow"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/falling_spore_blossom.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/falling_spore_blossom.json
@@ -1,0 +1,3 @@
+{
+	"material": "frex:emissive_no_diffuse"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/glow.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/glow.json
@@ -1,0 +1,3 @@
+{
+	"material": "frex:emissive_no_diffuse"
+}

--- a/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/spore_blossom_air.json
+++ b/src/main/resources/resourcepacks/canvas_default/assets/minecraft/materialmaps/particle/spore_blossom_air.json
@@ -1,0 +1,3 @@
+{
+	"material": "frex:emissive_no_diffuse"
+}


### PR DESCRIPTION
Adds the following emmissives to canvas_default:
#### Items:
- Light Block
- Glow Berries
- Glow Ink Sac
- Amethyst Shard
#### Block:
- Amethyst Cluster
- Amethyst Bud
- Lit Candle
- Glow Lichen
- Sculk Sensor
- Spore Blossom
- Caves Vines (glow berries glow on vines)
#### Entity:
- Glow Squid
#### Particles:
- Glow Squid Glow
- Spore Blossom Air
- Falling Spore Blossom
#### Hand Lighting:
- Light Block