### PR TITLE
Fix typo in bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**System Informatinon**
+**System Information**
 
 - Minecraft Version: 
 - Canvas Version: 


### PR DESCRIPTION
* Fixes a typo in line 10 of the template file where system information was read as "System Informatinon" instead.

Edits are welcome.