### PR TITLE
Change warm_glow material shader

### DIFF
--- a/src/main/resources/assets/canvas/shaders/material/warm_glow.frag
+++ b/src/main/resources/assets/canvas/shaders/material/warm_glow.frag
@@ -8,7 +8,7 @@
 void frx_materialFragment() {
 #ifndef DEPTH_PASS
 	float e = frx_luminance(frx_sampleColor.rgb);
-	bool lit = e >  0.8 || (0.4 * frx_sampleColor.r) > frx_sampleColor.b;
+	bool lit = e >  0.8 || ((0.4 * frx_sampleColor.r) > frx_sampleColor.b && e > 0.36);
 	frx_fragEmissive = lit ? e : 0.0;
 	frx_fragEnableDiffuse = frx_fragEnableDiffuse && !lit;
 	frx_fragEnableAo = frx_fragEnableAo && !lit;

--- a/src/main/resources/assets/canvas/shaders/material/warm_glow.frag
+++ b/src/main/resources/assets/canvas/shaders/material/warm_glow.frag
@@ -8,7 +8,7 @@
 void frx_materialFragment() {
 #ifndef DEPTH_PASS
 	float e = frx_luminance(frx_sampleColor.rgb);
-	bool lit = e >  0.8 || (frx_sampleColor.r - frx_sampleColor.b) > 0.3f;
+	bool lit = e >  0.8 || (0.4 * frx_sampleColor.r) > frx_sampleColor.b;
 	frx_fragEmissive = lit ? e : 0.0;
 	frx_fragEnableDiffuse = frx_fragEnableDiffuse && !lit;
 	frx_fragEnableAo = frx_fragEnableAo && !lit;


### PR DESCRIPTION
warm_glow currently has some issues with allowing things like wood to be emissive, which looks really weird. The detection algorithm is changed from subtraction to comparing the ratios
Before:
![2022-05-18_17 15 54 jpg](https://user-images.githubusercontent.com/60897356/169176576-8018139c-b092-4ba2-8646-ed1a64eb1241.jpg)
After:
![2022-05-18_17 13 29 jpg](https://user-images.githubusercontent.com/60897356/169176573-bc18fe2f-277f-4890-98c1-31fe96eaec5c.jpg)

Don't think it has any unintended side effects, but jack-o-lanterns still look a bit weird since they're fully emissive (but it's always been this way)