### PR TITLE
Rename Slider$NumberInput#setText to changeText

### DIFF
--- a/src/main/java/grondag/canvas/config/builder/Slider.java
+++ b/src/main/java/grondag/canvas/config/builder/Slider.java
@@ -131,7 +131,7 @@ public class Slider<T> extends OptionItem<Double> {
 
 	private void displayEdit() {
 		if (input != null) {
-			input.setText(format.format(getter.get()));
+			input.changeText(format.format(getter.get()));
 		}
 	}
 
@@ -182,7 +182,7 @@ public class Slider<T> extends OptionItem<Double> {
 			setResponder(this);
 		}
 
-		private void setText(String text) {
+		private void changeText(String text) {
 			suppressListener = true;
 			setValue(text);
 			suppressListener = false;


### PR DESCRIPTION
This makes so you can actually open the config screen in a yarn development environment. If the method is called setText and calls `setValue`, which gets remapped to `setText` in yarn, you will get infinite recursion and a fine stack overflow