### PR TITLE
Dynamic properties in pipeline configuration

### DIFF
--- a/src/main/java/grondag/canvas/pipeline/GlSymbolLookup.java
+++ b/src/main/java/grondag/canvas/pipeline/GlSymbolLookup.java
@@ -68,6 +68,10 @@ public class GlSymbolLookup {
 			symbol = config.get(String.class, key);
 		}
 
+		return lookup(symbol, fallback);
+	}
+
+	public static int lookup(String symbol, String fallback) {
 		int result = GlSymbolLookup.lookup(symbol);
 
 		if (result == -1 && !symbol.equals(fallback)) {

--- a/src/main/java/grondag/canvas/pipeline/config/AttachmentConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/AttachmentConfig.java
@@ -85,7 +85,7 @@ public class AttachmentConfig extends AbstractConfig {
 		final AttachmentConfig[] result = new AttachmentConfig[limit];
 
 		for (int i = 0; i < limit; ++i) {
-			result[i] = new AttachmentConfig(ctx, (JsonObject) array.get(i), false);
+			result[i] = new AttachmentConfig(ctx, ctx.dynamic.getAttachment(array.get(i)), false);
 		}
 
 		return result;

--- a/src/main/java/grondag/canvas/pipeline/config/AttachmentConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/AttachmentConfig.java
@@ -48,17 +48,17 @@ public class AttachmentConfig extends AbstractConfig {
 			clearColor = 0;
 			clearDepth = 1.0f;
 		} else {
-			image = context.images.dependOn(config, "image");
-			lod = config.getInt("lod", 0);
-			layer = config.getInt("layer", 0);
+			image = context.images.dependOn(context.dynamic.getString(config, "image"));
+			lod = context.dynamic.getInt(config, "lod", 0);
+			layer = context.dynamic.getInt(config, "layer", 0);
 
 			if (isDepth) {
 				clear = config.containsKey("clearDepth");
-				clearDepth = config.getFloat("clearDepth", 1.0f);
+				clearDepth = context.dynamic.getFloat(config, "clearDepth", 1.0f);
 				clearColor = 0;
 			} else {
 				clear = config.containsKey("clearColor");
-				clearColor = config.getInt("clearColor", 0);
+				clearColor = context.dynamic.getInt(config, "clearColor", 0);
 				clearDepth = 1.0f;
 			}
 		}

--- a/src/main/java/grondag/canvas/pipeline/config/DrawTargetsConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/DrawTargetsConfig.java
@@ -46,12 +46,12 @@ public class DrawTargetsConfig extends AbstractConfig {
 
 	DrawTargetsConfig (ConfigContext ctx, JsonObject config) {
 		super(ctx);
-		solidTerrain = ctx.frameBuffers.dependOn(config, "solidTerrain");
-		translucentTerrain = ctx.frameBuffers.dependOn(config, "translucentTerrain");
-		translucentEntity = ctx.frameBuffers.dependOn(config, "translucentEntity");
-		weather = ctx.frameBuffers.dependOn(config, "weather");
-		clouds = ctx.frameBuffers.dependOn(config, "clouds");
-		translucentParticles = ctx.frameBuffers.dependOn(config, "translucentParticles");
+		solidTerrain = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "solidTerrain"));
+		translucentTerrain = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "translucentTerrain"));
+		translucentEntity = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "translucentEntity"));
+		weather = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "weather"));
+		clouds = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "clouds"));
+		translucentParticles = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "translucentParticles"));
 	}
 
 	public static DrawTargetsConfig makeDefault(ConfigContext ctx) {

--- a/src/main/java/grondag/canvas/pipeline/config/FabulousConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/FabulousConfig.java
@@ -35,11 +35,11 @@ public class FabulousConfig extends AbstractConfig {
 
 	FabulousConfig (ConfigContext ctx, JsonObject config) {
 		super(ctx);
-		entityFramebuffer = ctx.frameBuffers.dependOn(config, "entity");
-		particleFramebuffer = ctx.frameBuffers.dependOn(config, "particles");
-		weatherFramebuffer = ctx.frameBuffers.dependOn(config, "weather");
-		cloudsFramebuffer = ctx.frameBuffers.dependOn(config, "clouds");
-		translucentFramebuffer = ctx.frameBuffers.dependOn(config, "translucent");
+		entityFramebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "entity"));
+		particleFramebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "particles"));
+		weatherFramebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "weather"));
+		cloudsFramebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "clouds"));
+		translucentFramebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "translucent"));
 	}
 
 	@Override

--- a/src/main/java/grondag/canvas/pipeline/config/FramebufferConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/FramebufferConfig.java
@@ -36,7 +36,7 @@ public class FramebufferConfig extends NamedConfig<FramebufferConfig> {
 		colorAttachments = AttachmentConfig.deserialize(ctx, config);
 
 		if (config.containsKey("depthAttachment")) {
-			depthAttachment = new AttachmentConfig(ctx, config.getObject("depthAttachment"), true);
+			depthAttachment = new AttachmentConfig(ctx, ctx.dynamic.getAttachment(config, "depthAttachment"), true);
 		} else {
 			depthAttachment = null;
 		}

--- a/src/main/java/grondag/canvas/pipeline/config/ImageConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/ImageConfig.java
@@ -77,10 +77,10 @@ public class ImageConfig extends NamedConfig<ImageConfig> {
 		super(ctx, config.get(String.class, "name"));
 		target = ctx.dynamic.getGlConst(config, "target", "TEXTURE_2D");
 		internalFormat = ctx.dynamic.getGlConst(config, "internalFormat", "RGBA8");
-		lod = ctx.dynamic.getInt(config,"lod", 0);
+		lod = ctx.dynamic.getInt(config, "lod", 0);
 		pixelFormat = ctx.dynamic.getGlConst(config, "pixelFormat", "RGBA");
 		pixelDataType = ctx.dynamic.getGlConst(config, "pixelDataType", "UNSIGNED_BYTE");
-		depth = ctx.dynamic.getInt(config,"depth", 1);
+		depth = ctx.dynamic.getInt(config, "depth", 1);
 
 		final int size = ctx.dynamic.getInt(config, "size", 0);
 		width = ctx.dynamic.getInt(config, "width", size);

--- a/src/main/java/grondag/canvas/pipeline/config/ImageConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/ImageConfig.java
@@ -75,16 +75,16 @@ public class ImageConfig extends NamedConfig<ImageConfig> {
 
 	ImageConfig (ConfigContext ctx, JsonObject config) {
 		super(ctx, config.get(String.class, "name"));
-		target = GlSymbolLookup.lookup(config, "target", "TEXTURE_2D");
-		internalFormat = GlSymbolLookup.lookup(config, "internalFormat", "RGBA8");
-		lod = config.getInt("lod", 0);
-		pixelFormat = GlSymbolLookup.lookup(config, "pixelFormat", "RGBA");
-		pixelDataType = GlSymbolLookup.lookup(config, "pixelDataType", "UNSIGNED_BYTE");
-		depth = config.getInt("depth", 1);
+		target = ctx.dynamic.getGlConst(config, "target", "TEXTURE_2D");
+		internalFormat = ctx.dynamic.getGlConst(config, "internalFormat", "RGBA8");
+		lod = ctx.dynamic.getInt(config,"lod", 0);
+		pixelFormat = ctx.dynamic.getGlConst(config, "pixelFormat", "RGBA");
+		pixelDataType = ctx.dynamic.getGlConst(config, "pixelDataType", "UNSIGNED_BYTE");
+		depth = ctx.dynamic.getInt(config,"depth", 1);
 
-		final int size = config.getInt("size", 0);
-		width = config.getInt("width", size);
-		height = config.getInt("height", size);
+		final int size = ctx.dynamic.getInt(config, "size", 0);
+		width = ctx.dynamic.getInt(config, "width", size);
+		height = ctx.dynamic.getInt(config, "height", size);
 
 		if (!config.containsKey("texParams")) {
 			texParamPairs = new int[0];
@@ -97,8 +97,8 @@ public class ImageConfig extends NamedConfig<ImageConfig> {
 
 			for (int i = 0; i < limit; ++i) {
 				final JsonObject p = (JsonObject) params.get(i);
-				texParamPairs[j++] = GlSymbolLookup.lookup(p, "name", "NONE");
-				texParamPairs[j++] = GlSymbolLookup.lookup(p, "val", "NONE");
+				texParamPairs[j++] = ctx.dynamic.getGlConst(p, "name", "NONE");
+				texParamPairs[j++] = ctx.dynamic.getGlConst(p, "val", "NONE");
 			}
 		}
 	}

--- a/src/main/java/grondag/canvas/pipeline/config/PassConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PassConfig.java
@@ -68,15 +68,15 @@ public class PassConfig extends NamedConfig<PassConfig> {
 
 	@SuppressWarnings("unchecked")
 	PassConfig (ConfigContext ctx, JsonObject config) {
-		super(ctx, JanksonHelper.asStringOrDefault(config.get("name"), JanksonHelper.asString(config.get("framebuffer"))));
-		framebuffer = ctx.frameBuffers.dependOn(config, "framebuffer");
-		program = ctx.programs.dependOn(config, "program");
-		toggleConfig = ctx.booleanConfigEntries.dependOn(config, "toggleConfig");
+		super(ctx, JanksonHelper.asStringOrDefault(config.get("name"), ctx.dynamic.getString(config, "framebuffer")));
+		framebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "framebuffer"));
+		program = ctx.programs.dependOn(ctx.dynamic.getString(config, "program"));
+		toggleConfig = ctx.booleanConfigEntries.dependOn(ctx.dynamic.getString(config, "toggleConfig"));
 
-		lod = config.getInt("lod", 0);
-		layer = config.getInt("layer", 0);
-		width = config.getInt("width", 0);
-		height = config.getInt("height", 0);
+		lod = ctx.dynamic.getInt(config, "lod", 0);
+		layer = ctx.dynamic.getInt(config, "layer", 0);
+		width = ctx.dynamic.getInt(config, "width", 0);
+		height = ctx.dynamic.getInt(config, "height", 0);
 
 		if (!config.containsKey("samplerImages")) {
 			samplerImages = new NamedDependency[0];
@@ -86,7 +86,7 @@ public class PassConfig extends NamedConfig<PassConfig> {
 			samplerImages = new NamedDependency[limit];
 
 			for (int i = 0; i < limit; ++i) {
-				samplerImages[i] = ctx.images.dependOn(names.get(i));
+				samplerImages[i] = ctx.images.dependOn(ctx.dynamic.getString(names.get(i)));
 			}
 		}
 	}

--- a/src/main/java/grondag/canvas/pipeline/config/PipelineConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PipelineConfig.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.resources.ResourceLocation;
 
-import grondag.canvas.config.ConfigManager;
 import grondag.canvas.pipeline.config.option.OptionConfig;
 import grondag.canvas.pipeline.config.util.ConfigContext;
 import grondag.canvas.pipeline.config.util.NamedDependency;

--- a/src/main/java/grondag/canvas/pipeline/config/PipelineConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PipelineConfig.java
@@ -107,7 +107,7 @@ public class PipelineConfig {
 			optionMap.put(opt.includeToken, opt);
 		}
 
-		options = builder.options.toArray(new OptionConfig[builder.options.size()]);
+		options = builder.prebuiltOptions;
 
 		fabulous = builder.fabulous.toArray(new PassConfig[builder.fabulous.size()]);
 		images = builder.images.toArray(new ImageConfig[builder.images.size()]);
@@ -115,8 +115,6 @@ public class PipelineConfig {
 		framebuffers = builder.framebuffers.toArray(new FramebufferConfig[builder.framebuffers.size()]);
 		onWorldStart = builder.onWorldStart.toArray(new PassConfig[builder.onWorldStart.size()]);
 		afterRenderHand = builder.afterRenderHand.toArray(new PassConfig[builder.afterRenderHand.size()]);
-
-		ConfigManager.initPipelineOptions(options);
 	}
 
 	public String configSource(ResourceLocation id) {

--- a/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
@@ -93,13 +93,13 @@ public class PipelineConfigBuilder {
 	}
 
 	public void load(JsonObject configJson) {
-		smoothBrightnessBidirectionaly = configJson.getBoolean("smoothBrightnessBidirectionaly", smoothBrightnessBidirectionaly);
-		runVanillaClear = configJson.getBoolean("runVanillaClear", runVanillaClear);
-		brightnessSmoothingFrames = configJson.getInt("brightnessSmoothingFrames", brightnessSmoothingFrames);
-		rainSmoothingFrames = configJson.getInt("rainSmoothingFrames", rainSmoothingFrames);
-		thunderSmoothingFrames = configJson.getInt("thunderSmoothingFrames", thunderSmoothingFrames);
-		glslVersion = configJson.getInt("glslVersion", glslVersion);
-		enablePBR = configJson.getBoolean("enablePBR", enablePBR);
+		smoothBrightnessBidirectionaly = context.dynamic.getBoolean(configJson, "smoothBrightnessBidirectionaly", smoothBrightnessBidirectionaly);
+		runVanillaClear = context.dynamic.getBoolean(configJson, "runVanillaClear", runVanillaClear);
+		brightnessSmoothingFrames = context.dynamic.getInt(configJson, "brightnessSmoothingFrames", brightnessSmoothingFrames);
+		rainSmoothingFrames = context.dynamic.getInt(configJson, "rainSmoothingFrames", rainSmoothingFrames);
+		thunderSmoothingFrames = context.dynamic.getInt(configJson, "thunderSmoothingFrames", thunderSmoothingFrames);
+		glslVersion = context.dynamic.getInt(configJson, "glslVersion", glslVersion);
+		enablePBR = context.dynamic.getBoolean(configJson, "enablePBR", enablePBR);
 
 		if (configJson.containsKey("materialProgram")) {
 			if (materialProgram == null) {
@@ -111,7 +111,7 @@ public class PipelineConfigBuilder {
 
 		if (configJson.containsKey("defaultFramebuffer")) {
 			if (defaultFramebuffer == null) {
-				defaultFramebuffer = context.frameBuffers.dependOn(configJson, "defaultFramebuffer");
+				defaultFramebuffer = context.frameBuffers.dependOn(context.dynamic.getString(configJson, "defaultFramebuffer"));
 			} else {
 				CanvasMod.LOG.warn("Invalid pipeline config - duplicate 'defaultFramebuffer' ignored.");
 			}

--- a/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
@@ -69,7 +69,7 @@ public class PipelineConfigBuilder {
 	public boolean runVanillaClear = true;
 	public int glslVersion = 330;
 	public boolean enablePBR = false;
-z`
+
 	public NamedDependency<FramebufferConfig> defaultFramebuffer;
 
 	public MaterialProgramConfig materialProgram;

--- a/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
+++ b/src/main/java/grondag/canvas/pipeline/config/PipelineConfigBuilder.java
@@ -51,6 +51,7 @@ public class PipelineConfigBuilder {
 	public final ObjectArrayList<ProgramConfig> programs = new ObjectArrayList<>();
 	public final ObjectArrayList<FramebufferConfig> framebuffers = new ObjectArrayList<>();
 	public final ObjectArrayList<OptionConfig> options = new ObjectArrayList<>();
+	public OptionConfig[] prebuiltOptions;
 
 	public final ObjectArrayList<PassConfig> onWorldStart = new ObjectArrayList<>();
 	public final ObjectArrayList<PassConfig> afterRenderHand = new ObjectArrayList<>();
@@ -68,10 +69,28 @@ public class PipelineConfigBuilder {
 	public boolean runVanillaClear = true;
 	public int glslVersion = 330;
 	public boolean enablePBR = false;
-
+z`
 	public NamedDependency<FramebufferConfig> defaultFramebuffer;
 
 	public MaterialProgramConfig materialProgram;
+
+	/**
+	 * Priority-pass loading. Loads options before anything else. This is necessary for the
+	 * current design of {@link grondag.canvas.pipeline.config.util.DynamicLoader}, at the cost
+	 * of reading the disk twice.
+	 *
+	 * @param configJson the json file being read
+	 */
+	public void loadPriority(JsonObject configJson) {
+		LoadHelper.loadList(context, configJson, "options", options, OptionConfig::new);
+	}
+
+	/**
+	 * Initialize the options immediately after all of them are loaded.
+	 */
+	private void afterLoadPriority() {
+		ConfigManager.initPipelineOptions(prebuiltOptions = options.toArray(new OptionConfig[options.size()]));
+	}
 
 	public void load(JsonObject configJson) {
 		smoothBrightnessBidirectionaly = configJson.getBoolean("smoothBrightnessBidirectionaly", smoothBrightnessBidirectionaly);
@@ -145,7 +164,6 @@ public class PipelineConfigBuilder {
 		LoadHelper.loadList(context, configJson, "images", images, ImageConfig::new);
 		LoadHelper.loadList(context, configJson, "programs", programs, ProgramConfig::new);
 		LoadHelper.loadList(context, configJson, "framebuffers", framebuffers, FramebufferConfig::new);
-		LoadHelper.loadList(context, configJson, "options", options, OptionConfig::new);
 	}
 
 	public boolean validate() {
@@ -188,40 +206,29 @@ public class PipelineConfigBuilder {
 
 		final PipelineConfigBuilder result = new PipelineConfigBuilder();
 		final ObjectOpenHashSet<ResourceLocation> included = new ObjectOpenHashSet<>();
-		final ObjectArrayFIFOQueue<ResourceLocation> queue = new ObjectArrayFIFOQueue<>();
+		final ObjectArrayFIFOQueue<ResourceLocation> readQueue = new ObjectArrayFIFOQueue<>();
+		final ObjectArrayFIFOQueue<JsonObject> primaryLoadQueue = new ObjectArrayFIFOQueue<>();
+		final ObjectArrayFIFOQueue<JsonObject> secondLoadQueue = new ObjectArrayFIFOQueue<>();
 
-		queue.enqueue(id);
+		readQueue.enqueue(id);
 		included.add(id);
 
-		while (!queue.isEmpty()) {
-			ResourceLocation target = queue.dequeue();
+		while (!readQueue.isEmpty()) {
+			final ResourceLocation target = readQueue.dequeue();
+			readResource(target, readQueue, primaryLoadQueue, included, rm);
+		}
 
-			// Allow flexibility on JSON vs JSON5 extensions
-			if (rm.getResource(target).isEmpty()) {
-				if (target.getPath().endsWith("json5")) {
-					final var candidate = new ResourceLocation(target.getNamespace(), target.getPath().substring(0, target.getPath().length() - 1));
+		while (!primaryLoadQueue.isEmpty()) {
+			final JsonObject target = primaryLoadQueue.dequeue();
+			secondLoadQueue.enqueue(target);
+			result.loadPriority(target);
+		}
 
-					if (rm.getResource(candidate).isPresent()) {
-						target = candidate;
-					}
-				} else if (target.getPath().endsWith("json")) {
-					final var candidate = new ResourceLocation(target.getNamespace(), target.getPath() + "5");
+		result.afterLoadPriority();
 
-					if (rm.getResource(candidate).isPresent()) {
-						target = candidate;
-					}
-				}
-			}
-
-			try (InputStream inputStream = rm.getResource(target).get().open()) {
-				final JsonObject configJson = ConfigManager.JANKSON.load(inputStream);
-				result.load(configJson);
-				getIncludes(configJson, included, queue);
-			} catch (final IOException | NoSuchElementException e) {
-				CanvasMod.LOG.warn(String.format("Unable to load pipeline config resource %s due to IOException: %s", target.toString(), e.getLocalizedMessage()));
-			} catch (final SyntaxError e) {
-				CanvasMod.LOG.warn(String.format("Unable to load pipeline config resource %s due to Syntax Error: %s", target.toString(), e.getLocalizedMessage()));
-			}
+		while (!secondLoadQueue.isEmpty()) {
+			final JsonObject target = secondLoadQueue.dequeue();
+			result.load(target);
 		}
 
 		if (result.validate()) {
@@ -229,6 +236,35 @@ public class PipelineConfigBuilder {
 		} else {
 			// fallback to minimal renderable pipeline if not valid
 			return null;
+		}
+	}
+
+	private static void readResource(ResourceLocation target, ObjectArrayFIFOQueue<ResourceLocation> queue, ObjectArrayFIFOQueue<JsonObject> loadQueue, ObjectOpenHashSet<ResourceLocation> included, ResourceManager rm) {
+		// Allow flexibility on JSON vs JSON5 extensions
+		if (rm.getResource(target).isEmpty()) {
+			if (target.getPath().endsWith("json5")) {
+				final var candidate = new ResourceLocation(target.getNamespace(), target.getPath().substring(0, target.getPath().length() - 1));
+
+				if (rm.getResource(candidate).isPresent()) {
+					target = candidate;
+				}
+			} else if (target.getPath().endsWith("json")) {
+				final var candidate = new ResourceLocation(target.getNamespace(), target.getPath() + "5");
+
+				if (rm.getResource(candidate).isPresent()) {
+					target = candidate;
+				}
+			}
+		}
+
+		try (InputStream inputStream = rm.getResource(target).get().open()) {
+			final JsonObject configJson = ConfigManager.JANKSON.load(inputStream);
+			loadQueue.enqueue(configJson);
+			getIncludes(configJson, included, queue);
+		} catch (final IOException | NoSuchElementException e) {
+			CanvasMod.LOG.warn(String.format("Unable to load pipeline config resource %s due to IOException: %s", target.toString(), e.getLocalizedMessage()));
+		} catch (final SyntaxError e) {
+			CanvasMod.LOG.warn(String.format("Unable to load pipeline config resource %s due to Syntax Error: %s", target.toString(), e.getLocalizedMessage()));
 		}
 	}
 

--- a/src/main/java/grondag/canvas/pipeline/config/ProgramConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/ProgramConfig.java
@@ -36,8 +36,8 @@ public class ProgramConfig extends NamedConfig<ProgramConfig> {
 
 	ProgramConfig(ConfigContext ctx, JsonObject config, String name) {
 		super(ctx, name);
-		vertexSource = new ResourceLocation(config.get(String.class, "vertexSource"));
-		fragmentSource = new ResourceLocation(config.get(String.class, "fragmentSource"));
+		vertexSource = new ResourceLocation(ctx.dynamic.getString(config, "vertexSource", "canvas:missing_shader"));
+		fragmentSource = new ResourceLocation(ctx.dynamic.getString(config, "fragmentSource", "canvas:missing_shader"));
 		samplerNames = readerSamplerNames(ctx, config, "program " + name);
 		isBuiltIn = false;
 	}

--- a/src/main/java/grondag/canvas/pipeline/config/SkyConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/SkyConfig.java
@@ -30,7 +30,7 @@ public class SkyConfig extends AbstractConfig {
 
 	SkyConfig (ConfigContext ctx, JsonObject config) {
 		super(ctx);
-		defaultZenithAngle = config.getFloat("defaultZenithAngle", 0f);
+		defaultZenithAngle = ctx.dynamic.getFloat(config, "defaultZenithAngle", 0f);
 	}
 
 	@Override

--- a/src/main/java/grondag/canvas/pipeline/config/SkyShadowConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/SkyShadowConfig.java
@@ -22,7 +22,6 @@ package grondag.canvas.pipeline.config;
 
 import blue.endless.jankson.JsonArray;
 import blue.endless.jankson.JsonObject;
-import org.apache.commons.lang3.ObjectUtils;
 
 import net.minecraft.resources.ResourceLocation;
 
@@ -47,14 +46,14 @@ public class SkyShadowConfig extends AbstractConfig {
 
 	SkyShadowConfig (ConfigContext ctx, JsonObject config) {
 		super(ctx);
-		framebuffer = ctx.frameBuffers.dependOn(config, "framebuffer");
-		vertexSource = JanksonHelper.asIdentifier(ObjectUtils.defaultIfNull(config.get("vertexSource"), config.get("vertexShader")));
-		fragmentSource = JanksonHelper.asIdentifier(ObjectUtils.defaultIfNull(config.get("fragmentSource"), config.get("fragmentShader")));
-		allowEntities = config.getBoolean("allowEntities", true);
-		allowParticles = config.getBoolean("allowParticles", true);
-		supportForwardRender = config.getBoolean("supportForwardRender", true);
-		offsetSlopeFactor = config.getFloat("offsetSlopeFactor", DEFAULT_SHADOW_SLOPE_FACTOR);
-		offsetBiasUnits = config.getFloat("offsetBiasUnits", DEFAULT_SHADOW_BIAS_UNITS);
+		framebuffer = ctx.frameBuffers.dependOn(ctx.dynamic.getString(config, "framebuffer"));
+		vertexSource = ResourceLocation.tryParse(ctx.dynamic.getString(config, "vertexSource", ctx.dynamic.getString(config, "vertexShader")));
+		fragmentSource = ResourceLocation.tryParse(ctx.dynamic.getString(config, "fragmentSource", ctx.dynamic.getString(config, "fragmentShader")));
+		allowEntities = ctx.dynamic.getBoolean(config, "allowEntities", true);
+		allowParticles = ctx.dynamic.getBoolean(config, "allowParticles", true);
+		supportForwardRender = ctx.dynamic.getBoolean(config, "supportForwardRender", true);
+		offsetSlopeFactor = ctx.dynamic.getFloat(config, "offsetSlopeFactor", DEFAULT_SHADOW_SLOPE_FACTOR);
+		offsetBiasUnits = ctx.dynamic.getFloat(config, "offsetBiasUnits", DEFAULT_SHADOW_BIAS_UNITS);
 		samplerNames = readerSamplerNames(ctx, config, "shy shadows");
 
 		final JsonArray radii = JanksonHelper.getJsonArrayOrNull(config, "cascadeRadius", "Invalid pipeline skyShadow config: cascadeRadius must be an array.");
@@ -65,7 +64,7 @@ public class SkyShadowConfig extends AbstractConfig {
 			}
 
 			for (int i = 0; i < 3; ++i) {
-				final int r = radii.getInt(i, -1);
+				final int r = ctx.dynamic.getInt(radii.get(i), -1);
 
 				if (r <= 0) {
 					CanvasMod.LOG.warn("Invalid pipeline skyShadow config: cascadeRadius array must contain integers > 0.");

--- a/src/main/java/grondag/canvas/pipeline/config/option/FloatConfigEntry.java
+++ b/src/main/java/grondag/canvas/pipeline/config/option/FloatConfigEntry.java
@@ -73,6 +73,10 @@ public class FloatConfigEntry extends OptionConfigEntry<FloatConfigEntry> {
 		config.put(name, new JsonPrimitive(value));
 	}
 
+	public float value() {
+		return value;
+	}
+
 	@Override
 	public boolean validate() {
 		boolean valid = super.validate();

--- a/src/main/java/grondag/canvas/pipeline/config/option/IntConfigEntry.java
+++ b/src/main/java/grondag/canvas/pipeline/config/option/IntConfigEntry.java
@@ -71,6 +71,10 @@ public class IntConfigEntry extends OptionConfigEntry<IntConfigEntry> {
 		config.put(name, new JsonPrimitive(value));
 	}
 
+	public int value() {
+		return value;
+	}
+
 	@Override
 	public boolean validate() {
 		boolean valid = super.validate();

--- a/src/main/java/grondag/canvas/pipeline/config/util/AbstractConfig.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/AbstractConfig.java
@@ -55,7 +55,7 @@ public abstract class AbstractConfig {
 			final String[] samplerNames = new String[limit];
 
 			for (int i = 0; i < limit; ++i) {
-				final String s = JanksonHelper.asString(names.get(i));
+				final String s = ctx.dynamic.getString(names.get(i));
 
 				if (s == null) {
 					CanvasMod.LOG.warn(String.format("Sampler name %s (%d of %d) for %s is not a valid string and was skipped.",

--- a/src/main/java/grondag/canvas/pipeline/config/util/ConfigContext.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/ConfigContext.java
@@ -53,4 +53,6 @@ public class ConfigContext {
 	public final NamedDependencyMap<EnumConfigEntry> enumConfigEntries = new NamedDependencyMap<>();
 	public final NamedDependencyMap<FloatConfigEntry> floatConfigEntries = new NamedDependencyMap<>();
 	public final NamedDependencyMap<IntConfigEntry> intConfigEntries = new NamedDependencyMap<>();
+
+	public final DynamicLoader dynamic = new DynamicLoader(this);
 }

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -1,0 +1,328 @@
+/*
+ * This file is part of Canvas Renderer and is licensed to the project under
+ * terms that are compatible with the GNU Lesser General Public License.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership and licensing.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package grondag.canvas.pipeline.config.util;
+
+import java.util.Map;
+
+import blue.endless.jankson.JsonArray;
+import blue.endless.jankson.JsonElement;
+import blue.endless.jankson.JsonObject;
+import blue.endless.jankson.JsonPrimitive;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+import grondag.canvas.pipeline.GlSymbolLookup;
+import grondag.canvas.pipeline.config.option.BooleanConfigEntry;
+import grondag.canvas.pipeline.config.option.EnumConfigEntry;
+import grondag.canvas.pipeline.config.option.FloatConfigEntry;
+import grondag.canvas.pipeline.config.option.IntConfigEntry;
+
+/**
+ * Dynamic property loader. The dynamic resolvers are designed so that they may be stored for
+ * deferred use, but the current implementation simply reads the resolved value immediately.
+ */
+public class DynamicLoader {
+	private final ConfigContext ctx;
+
+	DynamicLoader(ConfigContext context) {
+		ctx = context;
+	}
+
+	public String getString(JsonObject config, String key, String defaultVal) {
+		final JsonElement element = config.get(key);
+		final Dynamic<String> resolver = deserialize(String.class, element, defaultVal);
+
+		if (resolver != null) {
+			return resolver.value();
+		}
+
+		return defaultVal;
+	}
+
+	public boolean getBoolean(JsonObject config, String key, boolean defaultVal) {
+		final JsonElement element = config.get(key);
+
+		if (element instanceof JsonPrimitive primitive) {
+			defaultVal = primitive.asBoolean(defaultVal);
+		}
+
+		final Dynamic<Boolean> resolver = deserialize(Boolean.class, element, defaultVal);
+
+		if (resolver != null) {
+			return resolver.value();
+		}
+
+		return defaultVal;
+	}
+
+	public int getInt(JsonObject config, String key, int defaultVal) {
+		final JsonElement element = config.get(key);
+
+		if (element instanceof JsonPrimitive primitive) {
+			defaultVal = primitive.asInt(defaultVal);
+		}
+
+		final Dynamic<Integer> resolver = deserialize(Integer.class, element, defaultVal);
+
+		if (resolver != null) {
+			return resolver.value();
+		}
+
+		return defaultVal;
+	}
+
+	public float getFloat (JsonObject config, String key, float defaultVal) {
+		final JsonElement element = config.get(key);
+
+		if (element instanceof JsonPrimitive primitive) {
+			defaultVal = primitive.asFloat(defaultVal);
+		}
+
+		final Dynamic<Float> resolver = deserialize(Float.class, element, defaultVal);
+
+		if (resolver != null) {
+			return resolver.value();
+		}
+
+		return defaultVal;
+	}
+
+	public int getGlConst(JsonObject config, String key, String fallback) {
+		final JsonElement element = config.get(key);
+		final Dynamic<String> resolver = deserialize(String.class, element, fallback);
+
+		if (resolver != null) {
+			return GlSymbolLookup.lookup(resolver.value(), fallback);
+		}
+
+		return GlSymbolLookup.lookup(fallback);
+	}
+
+	private <ForType> Dynamic<ForType> deserialize(Class<ForType> clazz, JsonElement element, ForType defaultVal) {
+		if (element instanceof JsonPrimitive primitive) {
+			final Object value = primitive.getValue();
+
+			if (clazz.isAssignableFrom(value.getClass())){
+				return new ConstantResolver<>(clazz.cast(value));
+			} else if (value instanceof CharSequence stringVal) {
+				return createResolver(clazz, stringVal.toString());
+			}
+		} else if (element instanceof JsonObject obj) {
+			return deserializeMap(clazz, obj, defaultVal);
+		}
+
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <ForType> Dynamic<ForType> createResolver(Class<ForType> clazz, String optionKey) {
+		if (clazz.equals(String.class)) {
+			return (Dynamic<ForType>) new StringResolver(optionKey);
+		}
+
+		if (clazz.equals(Boolean.class)) {
+			return (Dynamic<ForType>) new BooleanResolver(optionKey);
+		}
+
+		if (clazz.equals(Integer.class)) {
+			return (Dynamic<ForType>) new IntResolver(optionKey);
+		}
+
+		if (clazz.equals(Float.class)) {
+			return (Dynamic<ForType>) new FloatResolver(optionKey);
+		}
+
+		return null;
+	}
+
+	private <ForType> MapResolver<ForType> deserializeMap(Class<ForType> clazz, JsonObject obj, ForType defaultVal) {
+		final ForType suppliedDefault = obj.get(clazz, "default");
+		final JsonObject optionMap = obj.getObject("optionMap");
+
+		if (optionMap != null) {
+			final String optionKey = optionMap.get(String.class, "option");
+			final JsonArray jsonMap = optionMap.get(JsonArray.class, "map");
+
+			if (optionKey != null && jsonMap != null) {
+				return new MapResolver<>(clazz, optionKey, jsonMap, suppliedDefault == null ? defaultVal : suppliedDefault);
+			}
+		}
+
+		return null;
+	}
+
+	private static abstract class Dynamic<T> {
+		public abstract T value();
+	}
+
+	private static class ConstantResolver<T> extends Dynamic<T> {
+		private final T value;
+
+		private ConstantResolver(T value) {
+			this.value = value;
+		}
+
+		@Override
+		public T value() {
+			return value;
+		}
+	}
+
+	private class MapResolver<ToType> extends Dynamic<ToType> {
+		private final Dynamic<Object> source;
+		private final Map<Object, ToType> map;
+		private final ToType defaultVal;
+
+		private MapResolver(Class<ToType> toType, String optionKey, JsonArray jsonMap, ToType defaultVal) {
+			this.source = new WildcardResolver(optionKey);
+			this.defaultVal = defaultVal;
+			map = new Object2ObjectOpenHashMap<>(jsonMap.size());
+
+			for (JsonElement element : jsonMap) {
+				if (element instanceof JsonObject obj) {
+					final var condition = obj.get(Object.class, "condition");
+					final var value = obj.get(toType, "value");
+
+					if (condition != null && value != null) {
+						map.put(condition, value);
+					}
+				}
+			}
+		}
+
+		@Override
+		public ToType value() {
+			return map.getOrDefault(source.value(), defaultVal);
+		}
+	}
+
+	private class WildcardResolver extends Dynamic<Object> {
+		private final String optionKey;
+
+		private WildcardResolver(String optionKey) {
+			this.optionKey = optionKey;
+		}
+
+		@Override
+		public Object value() {
+			var enumOption = ctx.enumConfigEntries.dependOn(optionKey);
+
+			if (enumOption != null) {
+				return enumOption.value();
+			}
+
+			var booleanOption = ctx.booleanConfigEntries.dependOn(optionKey);
+
+			if (booleanOption != null) {
+				return booleanOption.value();
+			}
+
+			var intOption = ctx.intConfigEntries.dependOn(optionKey);
+
+			if (intOption != null) {
+				return intOption.value();
+			}
+
+			var floatOption = ctx.floatConfigEntries.dependOn(optionKey);
+
+			if (floatOption != null) {
+				return floatOption.value();
+			}
+
+			return null;
+		}
+	}
+
+	private class StringResolver extends Dynamic<String> {
+		private final NamedDependency<EnumConfigEntry> optionEntry;
+
+		private StringResolver(String option) {
+			optionEntry = ctx.enumConfigEntries.dependOn(option);
+		}
+
+		@Override
+		public String value() {
+			final var option = optionEntry.value();
+
+			if (option == null) {
+				return null;
+			} else {
+				return option.value();
+			}
+		}
+	}
+
+	private class BooleanResolver extends Dynamic<Boolean> {
+		private final NamedDependency<BooleanConfigEntry> optionEntry;
+
+		private BooleanResolver(String option) {
+			optionEntry = ctx.booleanConfigEntries.dependOn(option);
+		}
+
+		@Override
+		public Boolean value() {
+			final var option = optionEntry.value();
+
+			if (option == null) {
+				return null;
+			} else {
+				return option.value();
+			}
+		}
+	}
+
+	private class IntResolver extends Dynamic<Integer> {
+		private final NamedDependency<IntConfigEntry> optionEntry;
+
+		private IntResolver(String option) {
+			optionEntry = ctx.intConfigEntries.dependOn(option);
+		}
+
+		@Override
+		public Integer value() {
+			final var option = optionEntry.value();
+
+			if (option == null) {
+				return null;
+			} else {
+				return option.value();
+			}
+		}
+	}
+
+	private class FloatResolver extends Dynamic<Float> {
+		private final NamedDependency<FloatConfigEntry> optionEntry;
+
+		private FloatResolver(String option) {
+			optionEntry = ctx.floatConfigEntries.dependOn(option);
+		}
+
+		@Override
+		public Float value() {
+			final var option = optionEntry.value();
+
+			if (option == null) {
+				return null;
+			} else {
+				return option.value();
+			}
+		}
+	}
+}

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -164,10 +164,18 @@ public class DynamicLoader {
 				defaultVal = suppliedDefault;
 			}
 
+			ForType resolved = null;
+
 			if (optionKey != null) {
-				return resolve(clazz, optionKey, defaultVal);
-			} else {
-				return deserializeMap(clazz, obj, defaultVal);
+				resolved = resolve(clazz, optionKey);
+			}
+
+			if (resolved == null) {
+				resolved = deserializeMap(clazz, obj);
+			}
+
+			if (resolved != null) {
+				return resolved;
 			}
 		}
 
@@ -175,7 +183,7 @@ public class DynamicLoader {
 	}
 
 	@SuppressWarnings("unchecked")
-	private <ForType> ForType resolve(Class<ForType> clazz, String optionKey, ForType defaultVal) {
+	private <ForType> ForType resolve(Class<ForType> clazz, String optionKey) {
 		if (clazz == String.class) {
 			var config = ctx.enumConfigEntries.get(optionKey);
 
@@ -216,10 +224,10 @@ public class DynamicLoader {
 			}
 		}
 
-		return defaultVal;
+		return null;
 	}
 
-	private <ForType> ForType deserializeMap(Class<ForType> clazz, JsonObject obj, ForType defaultVal) {
+	private <ForType> ForType deserializeMap(Class<ForType> clazz, JsonObject obj) {
 		final JsonObject optionMap = obj.getObject("optionMap");
 
 		if (optionMap != null) {
@@ -238,7 +246,7 @@ public class DynamicLoader {
 			}
 		}
 
-		return defaultVal;
+		return null;
 	}
 
 	private <ToType> ToType resolveSingleMap(Class<ToType> toType, String optionKey, JsonArray jsonMap) {

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -27,12 +27,9 @@ import blue.endless.jankson.JsonElement;
 import blue.endless.jankson.JsonObject;
 import blue.endless.jankson.JsonPrimitive;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.Nullable;
 
 import grondag.canvas.pipeline.GlSymbolLookup;
-import grondag.canvas.pipeline.config.option.BooleanConfigEntry;
-import grondag.canvas.pipeline.config.option.EnumConfigEntry;
-import grondag.canvas.pipeline.config.option.FloatConfigEntry;
-import grondag.canvas.pipeline.config.option.IntConfigEntry;
 
 /**
  * Loads json values verbatim or resolves values of user pipeline options when requested.
@@ -44,17 +41,39 @@ public class DynamicLoader {
 		ctx = context;
 	}
 
+	/**
+	 * Get a string verbatim or resolve dynamic string value.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @param defaultVal default string value if resolution fails or key not found
+	 * @return constant or resolved string value
+	 */
 	public String getString(JsonObject config, String key, String defaultVal) {
 		final JsonElement element = config.get(key);
 
-		return getString(element, defaultVal);
+		return getString(defaultVal, element);
 	}
 
-	public String getString(JsonElement element) {
-		return getString(element, "");
+	/**
+	 * Overload of {@link #getString(JsonObject, String, String)} with null default.
+	 */
+	public @Nullable String getString(JsonObject config, String key) {
+		return getString(config, key, null);
 	}
 
-	private String getString(JsonElement element, String defaultVal) {
+	/**
+	 * Read a Json element as a string constant or resolved dynamic string, or null if failed.
+	 *
+	 * @param element target Json element
+	 * @return resolved string value or null
+	 */
+	public @Nullable String getString(JsonElement element) {
+		return getString(null, element);
+	}
+
+	// Order of defaultVal reversed to not mistake it for json key
+	private String getString(String defaultVal, JsonElement element) {
 		if (element instanceof JsonPrimitive primitive && primitive.getValue() instanceof CharSequence) {
 			return primitive.asString();
 		} else {
@@ -62,6 +81,14 @@ public class DynamicLoader {
 		}
 	}
 
+	/**
+	 * Get a boolean verbatim or resolve dynamic boolean value.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @param defaultVal default boolean value if resolution fails or key not found
+	 * @return constant or resolved boolean value
+	 */
 	public boolean getBoolean(JsonObject config, String key, boolean defaultVal) {
 		final JsonElement element = config.get(key);
 
@@ -72,9 +99,27 @@ public class DynamicLoader {
 		}
 	}
 
+	/**
+	 * Get an integer verbatim or resolve dynamic integer value.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @param defaultVal default integer value if resolution fails or key not found
+	 * @return constant or resolved integer value
+	 */
 	public int getInt(JsonObject config, String key, int defaultVal) {
 		final JsonElement element = config.get(key);
+		return getInt(element, defaultVal);
+	}
 
+	/**
+	 * Read a Json element as an integer constant or resolved dynamic string.
+	 *
+	 * @param element target Json element
+	 * @param defaultVal default integer value if parsing or resolution fails
+	 * @return resolved integer value
+	 */
+	public int getInt(JsonElement element, int defaultVal) {
 		if (element instanceof JsonPrimitive primitive && primitive.getValue() instanceof Number) {
 			return primitive.asInt(defaultVal);
 		} else {
@@ -82,6 +127,14 @@ public class DynamicLoader {
 		}
 	}
 
+	/**
+	 * Get a float verbatim or resolve dynamic float value.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @param defaultVal default float value if resolution fails or key not found
+	 * @return constant or resolved float value
+	 */
 	public float getFloat (JsonObject config, String key, float defaultVal) {
 		final JsonElement element = config.get(key);
 
@@ -92,6 +145,14 @@ public class DynamicLoader {
 		}
 	}
 
+	/**
+	 * Get an GL enum int constant from a string constant or a resolved dynamic string.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @param fallback default GL enum in string form if resolution fails or key not found
+	 * @return GL enum integer constant
+	 */
 	public int getGlConst(JsonObject config, String key, String fallback) {
 		final String glEnum = getString(config, key, fallback);
 		return GlSymbolLookup.lookup(glEnum, fallback);

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -155,6 +155,30 @@ public class DynamicLoader {
 		return GlSymbolLookup.lookup(glEnum, fallback);
 	}
 
+	/**
+	 * Special handler for framebuffer attachment object.
+	 *
+	 * @param config source config object
+	 * @param key config key
+	 * @return parsed Json object
+	 */
+	public JsonObject getAttachment(JsonObject config, String key) {
+		return getAttachment(config.get(key));
+	}
+
+	public JsonObject getAttachment(JsonElement element) {
+		if (element instanceof JsonObject attachment) {
+			// prioritize framebuffer attachment "primitive"
+			if (attachment.containsKey("image")) {
+				return attachment;
+			} else {
+				return deserialize(JsonObject.class, attachment, null);
+			}
+		} else {
+			return null;
+		}
+	}
+
 	private <ForType> ForType deserialize(Class<ForType> clazz, JsonElement element, ForType defaultVal) {
 		if (element instanceof JsonObject obj) {
 			final String optionKey = obj.get(String.class, "option");
@@ -184,7 +208,10 @@ public class DynamicLoader {
 
 	@SuppressWarnings("unchecked")
 	private <ForType> ForType resolve(Class<ForType> clazz, String optionKey) {
-		if (clazz == String.class) {
+		if (clazz == JsonObject.class) {
+			// not supported
+			return null;
+		} else if (clazz == String.class) {
 			var config = ctx.enumConfigEntries.get(optionKey);
 
 			if (config != null) {

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -196,16 +196,30 @@ public class DynamicLoader {
 				return (ForType) Boolean.valueOf(config.value());
 			}
 		} else if (clazz == Integer.class) {
-			var config = ctx.intConfigEntries.get(optionKey);
+			var intOption = ctx.intConfigEntries.get(optionKey);
 
-			if (config != null) {
-				return (ForType) Integer.valueOf(config.value());
+			if (intOption != null) {
+				return (ForType) Integer.valueOf(intOption.value());
+			}
+
+			// also try float options
+			var floatOption = ctx.floatConfigEntries.get(optionKey);
+
+			if (floatOption != null) {
+				return (ForType) Integer.valueOf((int) floatOption.value());
 			}
 		} else if (clazz == Float.class) {
-			var config = ctx.floatConfigEntries.get(optionKey);
+			var floatOption = ctx.floatConfigEntries.get(optionKey);
 
-			if (config != null) {
-				return (ForType) Float.valueOf(config.value());
+			if (floatOption != null) {
+				return (ForType) Float.valueOf(floatOption.value());
+			}
+
+			// also try int options
+			var intOption = ctx.intConfigEntries.get(optionKey);
+
+			if (intOption != null) {
+				return (ForType) Float.valueOf((float) intOption.value());
 			}
 		}
 

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -119,7 +119,7 @@ public class DynamicLoader {
 		if (element instanceof JsonPrimitive primitive) {
 			final Object value = primitive.getValue();
 
-			if (clazz.isAssignableFrom(value.getClass())){
+			if (clazz.isAssignableFrom(value.getClass())) {
 				return new ConstantResolver<>(clazz.cast(value));
 			} else if (value instanceof CharSequence stringVal) {
 				return createResolver(clazz, stringVal.toString());
@@ -168,7 +168,7 @@ public class DynamicLoader {
 		return null;
 	}
 
-	private static abstract class Dynamic<T> {
+	private abstract static class Dynamic<T> {
 		public abstract T value();
 	}
 

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -161,6 +161,11 @@ public class DynamicLoader {
 	private <ForType> ForType deserialize(Class<ForType> clazz, JsonElement element, ForType defaultVal) {
 		if (element instanceof JsonObject obj) {
 			final String optionKey = obj.get(String.class, "useOption");
+			final ForType suppliedDefault = obj.get(clazz, "default");
+
+			if (suppliedDefault != null) {
+				defaultVal = suppliedDefault;
+			}
 
 			if (optionKey != null) {
 				return resolve(clazz, optionKey, defaultVal);
@@ -208,15 +213,14 @@ public class DynamicLoader {
 	}
 
 	private <ForType> MapResolver<ForType> deserializeMap(Class<ForType> clazz, JsonObject obj, ForType defaultVal) {
-		final ForType suppliedDefault = obj.get(clazz, "default");
-		final JsonObject optionMap = obj.getObject("optionMap");
+		final JsonObject optionMap = obj.getObject("useOptionMap");
 
 		if (optionMap != null) {
 			final String optionKey = optionMap.get(String.class, "option");
 			final JsonArray jsonMap = optionMap.get(JsonArray.class, "map");
 
 			if (optionKey != null && jsonMap != null) {
-				return new MapResolver<>(clazz, optionKey, jsonMap, suppliedDefault == null ? defaultVal : suppliedDefault);
+				return new MapResolver<>(clazz, optionKey, jsonMap, defaultVal);
 			}
 		}
 

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -197,11 +197,11 @@ public class DynamicLoader {
 
 			for (JsonElement element : jsonMap) {
 				if (element instanceof JsonObject obj) {
-					final var condition = obj.get(Object.class, "condition");
+					final var condition = obj.get(JsonPrimitive.class, "condition");
 					final var value = obj.get(toType, "value");
 
 					if (condition != null && value != null) {
-						map.put(condition, value);
+						map.put(condition.getValue(), value);
 					}
 				}
 			}
@@ -222,28 +222,44 @@ public class DynamicLoader {
 
 		@Override
 		public Object value() {
-			var enumOption = ctx.enumConfigEntries.dependOn(optionKey);
+			final var enumOption = ctx.enumConfigEntries.dependOn(optionKey);
 
 			if (enumOption != null) {
-				return enumOption.value();
+				final var entry = enumOption.value();
+
+				if (entry != null) {
+					return entry.value();
+				}
 			}
 
-			var booleanOption = ctx.booleanConfigEntries.dependOn(optionKey);
+			final var booleanOption = ctx.booleanConfigEntries.dependOn(optionKey);
 
 			if (booleanOption != null) {
-				return booleanOption.value();
+				final var entry = booleanOption.value();
+
+				if (entry != null) {
+					return entry.value();
+				}
 			}
 
-			var intOption = ctx.intConfigEntries.dependOn(optionKey);
+			final var intOption = ctx.intConfigEntries.dependOn(optionKey);
 
 			if (intOption != null) {
-				return intOption.value();
+				final var entry = intOption.value();
+
+				if (entry != null) {
+					return entry.value();
+				}
 			}
 
-			var floatOption = ctx.floatConfigEntries.dependOn(optionKey);
+			final var floatOption = ctx.floatConfigEntries.dependOn(optionKey);
 
 			if (floatOption != null) {
-				return floatOption.value();
+				final var entry = floatOption.value();
+
+				if (entry != null) {
+					return entry.value();
+				}
 			}
 
 			return null;

--- a/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
+++ b/src/main/java/grondag/canvas/pipeline/config/util/DynamicLoader.java
@@ -157,7 +157,7 @@ public class DynamicLoader {
 
 	private <ForType> ForType deserialize(Class<ForType> clazz, JsonElement element, ForType defaultVal) {
 		if (element instanceof JsonObject obj) {
-			final String optionKey = obj.get(String.class, "optionSource");
+			final String optionKey = obj.get(String.class, "option");
 			final ForType suppliedDefault = obj.get(clazz, "default");
 
 			if (suppliedDefault != null) {


### PR DESCRIPTION
### Definition

`Dynamic properties` are properties of pipeline (sub-)configuration that may be derived from the state of the user's pipeline options. For example, previously the size of an image config is always a constant, but now it may be derived from an int option.

### Usage

Since this PR, there are 3 ways to define a property (examples are in `json5` format):

1. Constant value

```json5
size: 128
```

2. Use option value

```json5
size: {
  default: 128,
  useOption: "texture_size"
}
```

Notes:
- The data type of the option must match the expected type of the property, otherwise the pipeline will fail to compile.
- Int and float are distinct option types. However, since float properties can receive int constant value, float properties can receive int option type as well.

3. Use mapping

```json5
size: {
  default: 128,
  useOptionMap: {
    option: "texture_size_selection",
    map: [
      {
        condition: "large",
        value: 256
      },
      {
        condition: "medium",
        value: 128
      },
      {
        condition: "small",
        value: 64
      }
    ]
}
```

Notes:
- Same rules as point number 2 applies.
- `useOption` is prioritized.
- Condition can be any type, so it's technically possible to map float values, but is impractical.

### Supported uses

- Any config properties with the type `String` (name references and GL enum constant), `Boolean`, `Int`, and `Float` are supported, including within an array or object.
- UPDATE: Attachment objects, that is the value of `depthAttachment` and the contents of `colorAttachments` arrays are supported _exceptionally_.

### Exceptions and Limitations

- Name definitions aren't supported (name _references_ are supported).
- Properties of options aren't supported; No recursion by design.
- Dynamic properties within dynamic properties aren't supported either.
- UPDATE: Arrays are not supported (_contents_ of arrays are supported).
  - Note: This is potentially a subject for future improvement, especially for ease-of-use reason. See [this comment](https://github.com/vram-guild/canvas/pull/389#issuecomment-1522822459).

If there is any property that is otherwise unsupported, it is a bug and please report it.

### Backward compatibility

Canvas will stay backward compatible with older pipelines. However, newer pipelines utilizing the dynamic properties won't be compatible with older Canvas. This is for simplicity reason, and not unreasonable as the current standard for "shaderpacks" (i.e. Iris/OF) is to provide support older version manually. Explicit support for `1.18.2` is already planned and prepared for.

### Implementation detail

This system works by first loading option configuration and stored option values before anything else in the pipeline, then applying those stored option values while reading the dynamic properties. No extra memory or execution footprint persists after the pipeline is fully loaded and running.
