### PR TITLE
enable `GL_TEXTURE_CUBE_MAP_SEAMLESS` ...

### DIFF
--- a/src/main/java/grondag/canvas/mixin/MixinMinecraft.java
+++ b/src/main/java/grondag/canvas/mixin/MixinMinecraft.java
@@ -40,6 +40,7 @@ import grondag.canvas.render.PrimaryFrameBuffer;
 import grondag.canvas.render.world.CanvasWorldRenderer;
 import grondag.canvas.shader.GlProgramManager;
 import grondag.canvas.varia.CanvasGlHelper;
+import grondag.canvas.varia.GFX;
 
 @Mixin(Minecraft.class)
 public abstract class MixinMinecraft extends ReentrantBlockableEventLoop<Runnable> {
@@ -50,6 +51,7 @@ public abstract class MixinMinecraft extends ReentrantBlockableEventLoop<Runnabl
 	@Inject(at = @At("RETURN"), method = "<init>*")
 	private void hookInit(CallbackInfo info) {
 		CanvasGlHelper.init();
+		GFX.enable(GFX.GL_TEXTURE_CUBE_MAP_SEAMLESS);
 	}
 
 	@Inject(at = @At("RETURN"), method = "runTick")

--- a/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
@@ -101,8 +101,10 @@ public class PipelineFramebuffer {
 						config.name, ac.image.name));
 			} else if (img.config.target == GFX.GL_TEXTURE_2D) {
 				GFX.glFramebufferTexture2D(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, img.config.target, img.glId(), ac.lod);
-			} else if (img.config.target == GFX.GL_TEXTURE_2D_ARRAY || img.config.target == GFX.GL_TEXTURE_3D || img.config.target == GFX.GL_TEXTURE_CUBE_MAP) {
+			} else if (img.config.target == GFX.GL_TEXTURE_2D_ARRAY || img.config.target == GFX.GL_TEXTURE_3D) {
 				GFX.glFramebufferTextureLayer(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, img.glId(), ac.lod, ac.layer);
+			} else if (img.config.target == GFX.GL_TEXTURE_CUBE_MAP) {
+				GFX.glFramebufferTexture2D(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, GFX.GL_TEXTURE_CUBE_MAP_POSITIVE_X + ac.layer, img.glId(), ac.lod);
 			}
 		}
 


### PR DESCRIPTION
... globally, at the `Minecraft` class constructor tail. Fixes cubemap texture linear filter.
Change `glFramebufferTextureLayer` call to `glFramebufferTexture2D` for cubemaps.