### PR TITLE
Small improvements

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -32,9 +32,9 @@ dependencies {
 
 // Hat tip to JellySquid
 configurations {
-    modIncludeImplementation
-    modImplementation.extendsFrom modIncludeImplementation
-    include.extendsFrom modIncludeImplementation
+	modIncludeImplementation
+	modImplementation.extendsFrom modIncludeImplementation
+	include.extendsFrom modIncludeImplementation
 }
 
 loom {
@@ -96,17 +96,17 @@ publishing {
 		if (project.version.endsWith('LOCAL') || project.version.endsWith('SNAPSHOT')) {
 			println "Snapshot build will be local only - not pushed to public maven"
 		} else {
-	    maven {
-        url = 'sftp://maven.vram.io:22'
-        credentials {
-        	if (project.hasProperty('maven_user')) {
-						username = project.getProperty('maven_user')
+		maven {
+			url = 'sftp://maven.vram.io:22'
+			credentials {
+				if (project.hasProperty('maven_user')) {
+							username = project.getProperty('maven_user')
+						}
+						if (project.hasProperty('maven_password')) {
+							password = project.getProperty('maven_password')
+						}
 					}
-					if (project.hasProperty('maven_password')) {
-						password = project.getProperty('maven_password')
-					}
-				}
-	    }
+			}
 		}
 	}
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -96,16 +96,16 @@ publishing {
 		if (project.version.endsWith('LOCAL') || project.version.endsWith('SNAPSHOT')) {
 			println "Snapshot build will be local only - not pushed to public maven"
 		} else {
-		maven {
-			url = 'sftp://maven.vram.io:22'
-			credentials {
-				if (project.hasProperty('maven_user')) {
-							username = project.getProperty('maven_user')
-						}
-						if (project.hasProperty('maven_password')) {
-							password = project.getProperty('maven_password')
-						}
+			maven {
+				url = 'sftp://maven.vram.io:22'
+				credentials {
+					if (project.hasProperty('maven_user')) {
+						username = project.getProperty('maven_user')
 					}
+					if (project.hasProperty('maven_password')) {
+						password = project.getProperty('maven_password')
+					}
+				}
 			}
 		}
 	}

--- a/fabric/project.gradle
+++ b/fabric/project.gradle
@@ -28,8 +28,8 @@ dependencies {
 
 	// Included via JMX
 	// modIncludeImplementation("io.vram:frex-fabric-mc118:6.0.258")
-	modImplementation("io.vram:jmx-fabric-mc119:1.22.264-SNAPSHOT")
-	include("io.vram:jmx-fabric-mc119:1.22.264-SNAPSHOT:fat")
+	modImplementation("io.vram:jmx-fabric-mc119:1.22.263")
+	include("io.vram:jmx-fabric-mc119:1.22.263:fat")
 
 	modCompileOnly "com.terraformersmc:modmenu:5.0.2"
 	modRuntimeOnly "com.terraformersmc:modmenu:5.0.2"

--- a/fabric/project.gradle
+++ b/fabric/project.gradle
@@ -28,8 +28,8 @@ dependencies {
 
 	// Included via JMX
 	// modIncludeImplementation("io.vram:frex-fabric-mc118:6.0.258")
-	modImplementation("io.vram:jmx-fabric-mc119:1.22.263")
-	include("io.vram:jmx-fabric-mc119:1.22.263:fat")
+	modImplementation("io.vram:jmx-fabric-mc119:1.22.264-SNAPSHOT")
+	include("io.vram:jmx-fabric-mc119:1.22.264-SNAPSHOT:fat")
 
 	modCompileOnly "com.terraformersmc:modmenu:5.0.2"
 	modRuntimeOnly "com.terraformersmc:modmenu:5.0.2"

--- a/fabric/settings.gradle
+++ b/fabric/settings.gradle
@@ -2,12 +2,12 @@
 // DO NOT MAKE CHANGES HERE - THEY WILL BE OVERWRITTEN BY AUTOMATED UPDATE
 
 pluginManagement {
-    repositories {
-      	mavenCentral()
-        maven {
-            name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
-        }
-        gradlePluginPortal()
-    }
+	repositories {
+		mavenCentral()
+		maven {
+			name = 'Fabric'
+			url = 'https://maven.fabricmc.net/'
+		}
+		gradlePluginPortal()
+	}
 }

--- a/src/main/java/grondag/canvas/material/state/RenderState.java
+++ b/src/main/java/grondag/canvas/material/state/RenderState.java
@@ -213,11 +213,9 @@ public final class RenderState {
 		texture.materialIndexProvider().enable();
 
 		if (Pipeline.shadowMapDepth != -1) {
-			CanvasTextureState.activeTextureUnit(TextureData.SHADOWMAP);
-			CanvasTextureState.bindTexture(GFX.GL_TEXTURE_2D_ARRAY, Pipeline.shadowMapDepth);
+			CanvasTextureState.ensureTextureOfTextureUnit(TextureData.SHADOWMAP, GFX.GL_TEXTURE_2D_ARRAY, Pipeline.shadowMapDepth);
+			CanvasTextureState.ensureTextureOfTextureUnit(TextureData.SHADOWMAP_TEXTURE, GFX.GL_TEXTURE_2D_ARRAY, Pipeline.shadowMapDepth);
 
-			CanvasTextureState.activeTextureUnit(TextureData.SHADOWMAP_TEXTURE);
-			CanvasTextureState.bindTexture(GFX.GL_TEXTURE_2D_ARRAY, Pipeline.shadowMapDepth);
 			// Set this back so nothing inadvertently tries to do stuff with array texture/shadowmap.
 			// Was seeing stray invalid operations errors in GL without.
 			CanvasTextureState.activeTextureUnit(TextureData.MC_SPRITE_ATLAS);
@@ -228,8 +226,7 @@ public final class RenderState {
 			for (int i = 0; i < Pipeline.config().materialProgram.samplerNames.length; i++) {
 				final int bindTarget = Pipeline.materialTextures().texTargets[i];
 				final int bind = Pipeline.materialTextures().texIds[i];
-				CanvasTextureState.activeTextureUnit(TextureData.PROGRAM_SAMPLERS + i);
-				CanvasTextureState.bindTexture(bindTarget, bind);
+				CanvasTextureState.ensureTextureOfTextureUnit(TextureData.PROGRAM_SAMPLERS + i, bindTarget, bind);
 			}
 
 			CanvasTextureState.activeTextureUnit(TextureData.MC_SPRITE_ATLAS);

--- a/src/main/java/grondag/canvas/mixin/MixinMinecraft.java
+++ b/src/main/java/grondag/canvas/mixin/MixinMinecraft.java
@@ -40,6 +40,7 @@ import grondag.canvas.render.PrimaryFrameBuffer;
 import grondag.canvas.render.world.CanvasWorldRenderer;
 import grondag.canvas.shader.GlProgramManager;
 import grondag.canvas.varia.CanvasGlHelper;
+import grondag.canvas.varia.GFX;
 
 @Mixin(Minecraft.class)
 public abstract class MixinMinecraft extends ReentrantBlockableEventLoop<Runnable> {
@@ -50,6 +51,7 @@ public abstract class MixinMinecraft extends ReentrantBlockableEventLoop<Runnabl
 	@Inject(at = @At("RETURN"), method = "<init>*")
 	private void hookInit(CallbackInfo info) {
 		CanvasGlHelper.init();
+		GFX.enable(GFX.GL_TEXTURE_CUBE_MAP_SEAMLESS);
 	}
 
 	@Inject(at = @At("RETURN"), method = "runTick")

--- a/src/main/java/grondag/canvas/pipeline/Image.java
+++ b/src/main/java/grondag/canvas/pipeline/Image.java
@@ -61,40 +61,23 @@ public class Image {
 				GFX.texParameter(config.target, params[i], params[++i]);
 			}
 
-			if (config.target == GFX.GL_TEXTURE_2D_ARRAY || config.target == GFX.GL_TEXTURE_3D) {
-				GFX.texImage3D(config.target, 0, config.internalFormat, width, height, config.depth, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
-			} else if (config.target == GFX.GL_TEXTURE_CUBE_MAP) {
-				for (int face = 0; face < 6; ++face) {
-					GFX.texImage2D(GFX.GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, 0, config.internalFormat, width, height, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
+			GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LEVEL, config.lod);
+			GFX.texParameter(config.target, GFX.GL_TEXTURE_MIN_LOD, 0);
+			GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LOD, config.lod);
+			GFX.texParameter(config.target, GFX.GL_TEXTURE_LOD_BIAS, 0.0F);
+
+			for (int i = 0; i <= config.lod; ++i) {
+				if (config.target == GFX.GL_TEXTURE_3D) {
+					GFX.texImage3D(config.target, i, config.internalFormat, width >> i, height >> i, config.depth >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
+				} else if (config.target == GFX.GL_TEXTURE_2D_ARRAY) {
+					GFX.texImage3D(config.target, i, config.internalFormat, width >> i, height >> i, config.depth, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
+				} else if (config.target == GFX.GL_TEXTURE_CUBE_MAP) {
+					for (int face = 0; face < 6; ++face) {
+						GFX.texImage2D(GFX.GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, i, config.internalFormat, width >> i, height >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
+					}
+				} else {
+					GFX.texImage2D(config.target, i, config.internalFormat, width >> i, height >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
 				}
-			} else {
-				assert config.target == GFX.GL_TEXTURE_2D;
-				GFX.texImage2D(config.target, 0, config.internalFormat, width, height, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
-			}
-
-			if (config.lod > 0) {
-				setupLod();
-			}
-		}
-	}
-
-	private void setupLod() {
-		GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LEVEL, config.lod);
-		GFX.texParameter(config.target, GFX.GL_TEXTURE_MIN_LOD, 0);
-		GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LOD, config.lod);
-		GFX.texParameter(config.target, GFX.GL_TEXTURE_LOD_BIAS, 0.0F);
-
-		for (int i = 1; i <= config.lod; ++i) {
-			if (config.target == GFX.GL_TEXTURE_3D) {
-				GFX.texImage3D(config.target, i, config.internalFormat, width >> i, height >> i, config.depth >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
-			} else if (config.target == GFX.GL_TEXTURE_2D_ARRAY) {
-				GFX.texImage3D(config.target, i, config.internalFormat, width >> i, height >> i, config.depth, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
-			} else if (config.target == GFX.GL_TEXTURE_CUBE_MAP) {
-				for (int face = 0; face < 6; ++face) {
-					GFX.texImage2D(GFX.GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, i, config.internalFormat, width >> i, height >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
-				}
-			} else {
-				GFX.texImage2D(config.target, i, config.internalFormat, width >> i, height >> i, 0, config.pixelFormat, config.pixelDataType, (ByteBuffer) null);
 			}
 		}
 	}

--- a/src/main/java/grondag/canvas/pipeline/Image.java
+++ b/src/main/java/grondag/canvas/pipeline/Image.java
@@ -61,10 +61,12 @@ public class Image {
 				GFX.texParameter(config.target, params[i], params[++i]);
 			}
 
-			GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LEVEL, config.lod);
-			GFX.texParameter(config.target, GFX.GL_TEXTURE_MIN_LOD, 0);
-			GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LOD, config.lod);
-			GFX.texParameter(config.target, GFX.GL_TEXTURE_LOD_BIAS, 0.0F);
+			if(config.lod > 0) {
+				GFX.texParameter(config.target, GFX.GL_TEXTURE_MIN_LOD, 0);
+				GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LOD, config.lod);
+				GFX.texParameter(config.target, GFX.GL_TEXTURE_MAX_LEVEL, config.lod);
+				GFX.texParameter(config.target, GFX.GL_TEXTURE_LOD_BIAS, 0.0F);
+			}
 
 			for (int i = 0; i <= config.lod; ++i) {
 				if (config.target == GFX.GL_TEXTURE_3D) {

--- a/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineFramebuffer.java
@@ -101,8 +101,10 @@ public class PipelineFramebuffer {
 						config.name, ac.image.name));
 			} else if (img.config.target == GFX.GL_TEXTURE_2D) {
 				GFX.glFramebufferTexture2D(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, img.config.target, img.glId(), ac.lod);
-			} else if (img.config.target == GFX.GL_TEXTURE_2D_ARRAY || img.config.target == GFX.GL_TEXTURE_3D || img.config.target == GFX.GL_TEXTURE_CUBE_MAP) {
+			} else if (img.config.target == GFX.GL_TEXTURE_2D_ARRAY || img.config.target == GFX.GL_TEXTURE_3D) {
 				GFX.glFramebufferTextureLayer(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, img.glId(), ac.lod, ac.layer);
+			} else if (img.config.target == GFX.GL_TEXTURE_CUBE_MAP) {
+				GFX.glFramebufferTexture2D(GFX.GL_FRAMEBUFFER, GFX.GL_COLOR_ATTACHMENT0 + i, GFX.GL_TEXTURE_CUBE_MAP_POSITIVE_X + ac.layer, img.glId(), ac.lod);
 			}
 		}
 

--- a/src/main/java/grondag/canvas/pipeline/PipelineManager.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineManager.java
@@ -166,10 +166,8 @@ public class PipelineManager {
 		final Matrix4f orthoMatrix = new Matrix4f().setOrtho(0.0F, (float)w, (float)h, 0.0F, 1000.0F, 3000.0F);
 		GFX.viewport(0, 0, w, h);
 		Pipeline.defaultFbo.bind();
-		CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE0);
-		//GlStateManager.disableTexture();
 
-		CanvasTextureState.bindTexture(target, glId);
+		CanvasTextureState.ensureTextureOfTextureUnit(GFX.GL_TEXTURE0, target, glId);
 
 		boolean isLayered = target == GFX.GL_TEXTURE_2D_ARRAY;
 

--- a/src/main/java/grondag/canvas/pipeline/PipelineManager.java
+++ b/src/main/java/grondag/canvas/pipeline/PipelineManager.java
@@ -100,11 +100,8 @@ public class PipelineManager {
 	}
 
 	static void beginFullFrameRender() {
-		// UGLY: put state preservation into texture manager
-		CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE1);
-		oldTex1 = CanvasTextureState.getActiveBoundTexture();
-		CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE0);
-		oldTex0 = CanvasTextureState.getActiveBoundTexture();
+		oldTex1 = CanvasTextureState.getBoundTexture(GFX.GL_TEXTURE1);
+		oldTex0 = CanvasTextureState.getBoundTexture(GFX.GL_TEXTURE0);
 
 		GFX.depthMask(false);
 		GFX.disableBlend();
@@ -115,11 +112,10 @@ public class PipelineManager {
 
 	static void endFullFrameRender() {
 		GFX.bindVertexArray(0);
-		CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE1);
-		CanvasTextureState.bindTexture(oldTex1);
-		//GlStateManager.disableTexture();
-		CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE0);
-		CanvasTextureState.bindTexture(oldTex0);
+
+		CanvasTextureState.ensureTextureOfTextureUnit(GFX.GL_TEXTURE0, GFX.GL_TEXTURE_2D, oldTex0);
+		CanvasTextureState.ensureTextureOfTextureUnit(GFX.GL_TEXTURE1, GFX.GL_TEXTURE_2D, oldTex1);
+
 		GlProgram.deactivate();
 		GFX.restoreProjectionMatrix();
 		GFX.depthMask(true);
@@ -220,6 +216,7 @@ public class PipelineManager {
 		debugDepthShader = new ProcessShader("debug_depth", new ResourceLocation("canvas:shaders/pipeline/post/simple_full_frame.vert"), new ResourceLocation("canvas:shaders/pipeline/post/visualize_depth.frag"), "_cvu_input");
 		debugDepthArrayShader = new ProcessShader("debug_depth_array", new ResourceLocation("canvas:shaders/pipeline/post/simple_full_frame.vert"), new ResourceLocation("canvas:shaders/pipeline/post/visualize_depth_array.frag"), "_cvu_input");
 		debugCubeMapShader = new ProcessShader("debug_cube_map", new ResourceLocation("canvas:shaders/pipeline/post/simple_full_frame.vert"), new ResourceLocation("canvas:shaders/pipeline/post/visualize_cube_map.frag"), "_cvu_input");
+
 		Pipeline.defaultFbo.bind();
 		CanvasTextureState.bindTexture(0);
 
@@ -255,6 +252,7 @@ public class PipelineManager {
 		debugArrayShader = ProcessShader.unload(debugArrayShader);
 		debugDepthShader = ProcessShader.unload(debugDepthShader);
 		debugDepthArrayShader = ProcessShader.unload(debugDepthArrayShader);
+		debugCubeMapShader = ProcessShader.unload(debugCubeMapShader);
 
 		if (drawBuffer != null) {
 			drawBuffer.release();

--- a/src/main/java/grondag/canvas/pipeline/pass/ProgramPass.java
+++ b/src/main/java/grondag/canvas/pipeline/pass/ProgramPass.java
@@ -65,8 +65,7 @@ class ProgramPass extends Pass {
 		final int slimit = textures.texIds.length;
 
 		for (int i = 0; i < slimit; ++i) {
-			CanvasTextureState.activeTextureUnit(GFX.GL_TEXTURE0 + i);
-			CanvasTextureState.bindTexture(textures.texTargets[i], textures.texIds[i]);
+			CanvasTextureState.ensureTextureOfTextureUnit(GFX.GL_TEXTURE0 + i, textures.texTargets[i], textures.texIds[i]);
 		}
 
 		shader.activate().lod(config.lod).layer(config.layer).size(width, height).projection(orthoMatrix);

--- a/src/main/java/grondag/canvas/render/CanvasTextureState.java
+++ b/src/main/java/grondag/canvas/render/CanvasTextureState.java
@@ -52,8 +52,15 @@ public class CanvasTextureState {
 		}
 	}
 
-	public static int getActiveBoundTexture() {
-		return BOUND_TEXTURES[activeTextureUnit];
+	public static int getBoundTexture(int textureUnit) {
+		return BOUND_TEXTURES[textureUnit - GFX.GL_TEXTURE0];
+	}
+
+	public static void ensureTextureOfTextureUnit(int textureUnit, int target, int texture) {
+		if(getBoundTexture(textureUnit) != texture) {
+			activeTextureUnit(textureUnit);
+			bindTexture(target, texture);
+		}
 	}
 
 	public static void activeTextureUnit(int textureUnit) {

--- a/src/main/java/grondag/canvas/render/CanvasTextureState.java
+++ b/src/main/java/grondag/canvas/render/CanvasTextureState.java
@@ -57,7 +57,7 @@ public class CanvasTextureState {
 	}
 
 	public static void ensureTextureOfTextureUnit(int textureUnit, int target, int texture) {
-		if(getBoundTexture(textureUnit) != texture) {
+		if (getBoundTexture(textureUnit) != texture) {
 			activeTextureUnit(textureUnit);
 			bindTexture(target, texture);
 		}


### PR DESCRIPTION
- backport cubemap fixes from `1.19` branch
- simplify pipeline texture initialisation
- unload `debugCubeMapShader`
- `CanvasTextureState.ensureTextureOfTextureUnit(int textureUnit, int target, int texture)`: calls `activeTextureUnit` and then `bindTexture` only if texture at `textureUnit` != `texture`. method name is subject to change