### PR TITLE
Flywheel Compat

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -19,15 +19,23 @@ plugins {
 
 ext.platform_name = 'fabric'
 ext.loader_version = '0.14.11'
-ext.fabric_version = '0.68.0+1.19.2'
+ext.fabric_version = '0.73.2+1.19.2'
 
 apply from: '../project_common.gradle'
 apply from: 'project.gradle'
 apply from: '../gruntle_common.gradle'
 
+repositories {
+	maven {
+		name "tterrag maven"
+		url "https://maven.tterrag.com/"
+	}
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:${minecraft_version}"
 	mappings loom.officialMojangMappings()
+	modCompileOnly "com.jozufozu.flywheel:flywheel-fabric-1.19.2:0.6.8.a-4"
 }
 
 // Hat tip to JellySquid

--- a/src/main/java/grondag/canvas/compat/FlywheelHolder.java
+++ b/src/main/java/grondag/canvas/compat/FlywheelHolder.java
@@ -1,0 +1,139 @@
+package grondag.canvas.compat;
+
+import com.jozufozu.flywheel.backend.Backend;
+import com.jozufozu.flywheel.backend.gl.GlStateTracker;
+import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
+import com.jozufozu.flywheel.backend.instancing.InstancedRenderRegistry;
+import com.jozufozu.flywheel.core.crumbling.CrumblingRenderer;
+import com.jozufozu.flywheel.event.BeginFrameEvent;
+import com.jozufozu.flywheel.event.ReloadRenderersEvent;
+import com.jozufozu.flywheel.event.RenderLayerEvent;
+import com.jozufozu.flywheel.fabric.event.FlywheelEvents;
+import com.mojang.blaze3d.vertex.PoseStack;
+import grondag.canvas.CanvasMod;
+import grondag.canvas.mixinterface.LevelRendererExt;
+import grondag.canvas.shader.data.MatrixData;
+import io.vram.frex.api.renderloop.WorldRenderContext;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Camera;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.RenderBuffers;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+public class FlywheelHolder {
+	private static final FlywheelHandler DEFAULT_HANDLER = new EmptyHandler();
+	public static FlywheelHandler handler = DEFAULT_HANDLER;
+
+	static {
+		if (FabricLoader.getInstance().isModLoaded("flywheel")) {
+			try {
+				handler = new CompatibleHandler();
+			} catch (final Throwable e) {
+				// what are the odds?
+				closeHandler(e);
+			}
+		}
+	}
+
+	public static class CompatibleHandler implements FlywheelHandler {
+		@Override
+		public void beginFrame(ClientLevel level, Camera camera, Frustum frustum) {
+			try {
+				FlywheelEvents.BEGIN_FRAME.invoker().handleEvent(new BeginFrameEvent(level, camera, frustum));
+			} catch (final Throwable ignored) {
+			}
+		}
+
+		@Override
+		public void renderLayer(LevelRenderer renderer, RenderType type, PoseStack stack, double camX, double camY, double camZ) {
+			try {
+				final LevelRendererExt ext = (LevelRendererExt) renderer;
+				RenderBuffers renderBuffers = ext.canvas_bufferBuilders();
+				GlStateTracker.State restoreState = GlStateTracker.getRestoreState();
+				// RenderLayerEvent computes the View-Projection matrix during construction
+				stack.pushPose();
+				stack.last().pose().load(MatrixData.viewMatrix);
+				var event = new RenderLayerEvent(ext.canvas_world(), type, stack, renderBuffers, camX, camY, camZ);
+				stack.popPose();
+
+				FlywheelEvents.RENDER_LAYER.invoker().handleEvent(event);
+				restoreState.restore();
+				// CanvasMod.LOG.warn("flywheel thing is invoked");
+			} catch (final Throwable ignored) {
+
+			}
+		}
+
+		@Override
+		public void renderCrumbling(ClientLevel level, Camera camera, PoseStack stack) {
+			CrumblingRenderer.render(level, camera, stack);
+		}
+
+		@Override
+		public boolean handleInstancing(BlockEntity blockEntity) {
+			Level world = blockEntity.getLevel();
+			if (!Backend.canUseInstancing(blockEntity.getLevel())) {
+				return false;
+			}
+
+			if (InstancedRenderRegistry.canInstance(blockEntity.getType())) {
+				InstancedRenderDispatcher.getBlockEntities(world).queueAdd(blockEntity);
+			}
+			return InstancedRenderRegistry.shouldSkipRender(blockEntity);
+		}
+
+		@Override
+		public void refresh(ClientLevel level) {
+			Backend.refresh();
+
+			FlywheelEvents.RELOAD_RENDERERS.invoker().handleEvent(new ReloadRenderersEvent(level));
+		}
+	}
+
+	private static void closeHandler(Throwable e) {
+		CanvasMod.LOG.warn("Unable to deffer to Flywheel due to exception: ", e);
+		CanvasMod.LOG.warn("Subsequent errors will be suppressed");
+		handler = DEFAULT_HANDLER;
+	}
+
+	public interface FlywheelHandler {
+		void beginFrame(ClientLevel level, Camera camera, Frustum frustum);
+
+		default void renderLayer(WorldRenderContext ctx, RenderType type) {
+			final var cam = ctx.camera().getPosition();
+			renderLayer(ctx.worldRenderer(), type, ctx.poseStack(), cam.x, cam.y, cam.z);
+		}
+
+		void renderLayer(LevelRenderer renderer, RenderType type, PoseStack stack, double camX, double camY, double camZ);
+
+		void renderCrumbling(ClientLevel level, Camera camera, PoseStack stack);
+
+		default boolean handleInstancing(BlockEntity blockEntity) {
+			return false;
+		}
+		void refresh(ClientLevel level);
+	}
+
+	private static final class EmptyHandler implements FlywheelHandler {
+
+		@Override
+		public void beginFrame(ClientLevel level, Camera camera, Frustum frustum) {
+		}
+
+		@Override
+		public void renderLayer(LevelRenderer renderer, RenderType type, PoseStack stack, double camX, double camY, double camZ) {
+		}
+
+		@Override
+		public void renderCrumbling(ClientLevel level, Camera camera, PoseStack stack) {
+		}
+
+		@Override
+		public void refresh(ClientLevel level) {
+		}
+	}
+}

--- a/src/main/java/grondag/canvas/compat/FlywheelHolder.java
+++ b/src/main/java/grondag/canvas/compat/FlywheelHolder.java
@@ -1,3 +1,23 @@
+/*
+ * This file is part of Canvas Renderer and is licensed to the project under
+ * terms that are compatible with the GNU Lesser General Public License.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership and licensing.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package grondag.canvas.compat;
 
 import com.jozufozu.flywheel.backend.Backend;

--- a/src/main/java/grondag/canvas/render/world/CanvasWorldRenderer.java
+++ b/src/main/java/grondag/canvas/render/world/CanvasWorldRenderer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 
+import grondag.canvas.compat.FlywheelHolder;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap.Entry;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
@@ -628,6 +629,7 @@ public class CanvasWorldRenderer extends LevelRenderer {
 		}
 
 		blockContext.encoder.collectors = immediate.collectors;
+		FlywheelHolder.handler.renderCrumbling(world, camera, identityStack);
 
 		WorldRenderDraws.profileSwap(profiler, ProfilerGroup.EndWorld, "outline");
 		final HitResult hitResult = mc.hitResult;

--- a/src/main/java/grondag/canvas/terrain/region/RenderRegion.java
+++ b/src/main/java/grondag/canvas/terrain/region/RenderRegion.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import grondag.canvas.compat.FlywheelHolder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -130,6 +131,8 @@ public class RenderRegion implements TerrainExecutorTask {
 	}
 
 	private static <E extends BlockEntity> void addBlockEntity(List<BlockEntity> chunkEntities, Set<BlockEntity> globalEntities, E blockEntity) {
+		if (FlywheelHolder.handler.handleInstancing(blockEntity))
+			return;
 		final BlockEntityRenderer<E> blockEntityRenderer = Minecraft.getInstance().getBlockEntityRenderDispatcher().getRenderer(blockEntity);
 
 		if (blockEntityRenderer != null) {


### PR DESCRIPTION
This PR fixes issues with Flywheel Compat allow canvas to be used with the Create mod. This is pretty much a copy of [spiralhalo](https://github.com/vram-guild/canvas/commits?author=spiralhalo) Flywheel branch, but it adds support for the CrumblingRenderer, and is based off the 1.19.2 branch and not 1.18.2

I'm not sure why the compat was never finished, if someone else is working on it or this has a technical problem feel free to just close this.