### PR TITLE
Replace deprecated texture2D() with texture()

### DIFF
--- a/src/main/resources/assets/canvas/shaders/pipeline/hd/hd.frag
+++ b/src/main/resources/assets/canvas/shaders/pipeline/hd/hd.frag
@@ -8,11 +8,11 @@ vec4 aoFactor(vec2 lightCoord) {
 	// Don't apply AO for item renders
 	#if CONTEXT_IS_BLOCK
 
-	vec4 hd = texture2D(u_utility, v_hd_lightmap);
+	vec4 hd = texture(u_utility, v_hd_lightmap);
 	float ao = hd.r;
 
 	#if ENABLE_LIGHT_NOISE
-	vec4 dither = texture2D(u_dither, gl_FragCoord.xy / 16.0);
+	vec4 dither = texture(u_dither, gl_FragCoord.xy / 16.0);
 	ao += dither.r / 16.0 - (1.0 / 32.0);
 	#endif
 
@@ -41,12 +41,12 @@ vec4 aoFactor(vec2 lightCoord) {
 
 vec2 lightCoord() {
 	#if ENABLE_SMOOTH_LIGHT
-	vec4 hd = texture2D(u_utility, v_hd_lightmap);
+	vec4 hd = texture(u_utility, v_hd_lightmap);
 	// PERF: return directly vs extra math below
 	vec2 lightCoord = vec2(hd.g, hd.a) * 15.0;
 
 	#if ENABLE_LIGHT_NOISE
-	vec4 dither = texture2D(u_dither, gl_FragCoord.xy / 8.0);
+	vec4 dither = texture(u_dither, gl_FragCoord.xy / 8.0);
 	lightCoord += dither.r / 64.0 - (1.0 / 128.0);
 	#endif
 

--- a/src/main/resources/resourcepacks/canvas_wip/assets/canvas/shaders/internal/material_main.frag
+++ b/src/main/resources/resourcepacks/canvas_wip/assets/canvas/shaders/internal/material_main.frag
@@ -39,7 +39,7 @@ vec4 aoFactor(vec2 lightCoord) {
 	#if AO_SHADING_MODE == AO_MODE_SUBTLE_ALWAYS
 	return vec4(bao, bao, bao, 1.0);
 	#else
-	vec4 sky = texture2D(frxs_lightmap, vec2(0.03125, lightCoord.y));
+	vec4 sky = texture(frxs_lightmap, vec2(0.03125, lightCoord.y));
 	ao = mix(bao, ao, frx_luminance(sky.rgb));
 	return vec4(ao, ao, ao, 1.0);
 	#endif
@@ -64,7 +64,7 @@ vec4 lightSample(vec3 pos, vec3 normal) {
 vec4 light(frx_FragmentData fragData) {
 	vec4 result;
 	vec4 block = lightSample(_cvv_worldcoord, _cvv_normal);
-	vec4 sky = texture2D(frxs_lightmap, vec2(0.03125, fragData.light.y));
+	vec4 sky = texture(frxs_lightmap, vec2(0.03125, fragData.light.y));
 
 #if DIFFUSE_SHADING_MODE == DIFFUSE_MODE_SKY_ONLY
 	if (fragData.diffuse) {
@@ -83,7 +83,7 @@ vec4 light(frx_FragmentData fragData) {
 		float d = clamp(gl_FogFragCoord / (held.w * HANDHELD_LIGHT_RADIUS), 0.0, 1.0);
 		d = 1.0 - d * d;
 
-		vec4 maxBlock = texture2D(frxs_lightmap, vec2(0.96875, 0.03125));
+		vec4 maxBlock = texture(frxs_lightmap, vec2(0.96875, 0.03125));
 
 		held = vec4(held.xyz, 1.0) * maxBlock * d;
 
@@ -102,7 +102,7 @@ void main() {
 #endif
 
 	frx_FragmentData fragData = frx_FragmentData (
-		texture2D(frxs_spriteAltas, _cvv_texcoord, _cv_getFlag(_CV_FLAG_UNMIPPED) * -4.0),
+		texture(frxs_spriteAltas, _cvv_texcoord, _cv_getFlag(_CV_FLAG_UNMIPPED) * -4.0),
 		_cvv_color,
 		frx_matEmissive() ? 1.0 : 0.0,
 		!frx_matDisableDiffuse(),

--- a/src/main/resources/resourcepacks/canvas_wip/assets/canvas/shaders/internal/material_main.vert
+++ b/src/main/resources/resourcepacks/canvas_wip/assets/canvas/shaders/internal/material_main.vert
@@ -45,7 +45,7 @@ void main() {
 	if (_cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE] != 0.0) {
 		float spriteIndex = in_material.x;
 		// for sprite atlas textures, convert from normalized (0-1) to interpolated coordinates
-		vec4 spriteBounds = texture2DLod(frxs_spriteInfo, vec2(0, spriteIndex / _cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE]), 0);
+		vec4 spriteBounds = textureLod(frxs_spriteInfo, vec2(0, spriteIndex / _cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE]), 0);
 
 		float atlasHeight = _cvu_atlas[_CV_ATLAS_HEIGHT];
 		float atlasWidth = _cvu_atlas[_CV_ATLAS_WIDTH];


### PR DESCRIPTION
`texture2D` has been deprecated as of OpenGL 3.3 in favor of `texture`. Although no graphics driver that I know of removes support for `texture2D`, I think it is still best to avoid deprecated functions.

This very simple change can also be backported easily, but I can't be bothered.